### PR TITLE
Add spring_ai directory to the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV RUNUSER=oracleaim
 RUN microdnf -y update
 RUN microdnf -y install python3.11 python3.11-pip 
 RUN python3.11 -m venv --symlinks --upgrade-deps /opt/venv
-COPY ./requirements.txt /opt/requirements.txt
+COPY app/requirements.txt /opt/requirements.txt
 RUN source /opt/venv/bin/activate && \
     pip3 install --upgrade pip wheel setuptools && \
     pip3 install -r /opt/requirements.txt
@@ -25,10 +25,11 @@ ARG ENVIRONMENT
 ENV PATH=/opt/venv/bin:$PATH
 
 #COPY THIRD_PARTY_LICENSES.txt /THIRD_PARTY_LICENSES.txt
-COPY entrypoint.sh /entrypoint.sh
+COPY app/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-COPY --chown=$RUNUSER:$RUNUSER src/ /app/
+COPY --chown=$RUNUSER:$RUNUSER app/src/ /app/
+COPY --chown=$RUNUSER:$RUNUSER spring_ai/ /spring_ai/
 # Copy the OCI directory if it exists
 ENV ENVIRONMENT=${ENVIRONMENT}
 RUN if [ -d "/app/.oci" ] && [ "$ENVIRONMENT" != "development" ]; then \

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ To run the application in a container; download the [source](https://github.com/
 
 1. Build the image.
 
-   From the `app/` directory, build Image:
+   From the root of the project, build Image:
 
    ```bash
    podman build -t oaim-sandbox .


### PR DESCRIPTION
 since it is used in the code and some UI actions error out due to its absence when running in Docker container e.g. changing temperature. Moved Dockerfile to top level so that spring_ai is part of the Docker context. Updated README as well.

A screenshot of the error is attached This was reproduced by running the sandbox in a container, opening the UI, importing a settings.json file and then changing the temperature setting in the Chatbot's left nav:
![Screenshot 2025-01-16 at 5 09 20 PM](https://github.com/user-attachments/assets/313ab323-f34d-4780-9dbb-b57355e62101)
