### PR TITLE
Docs renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To run the application on bare-metal; download the [source](https://github.com/o
 1. Start Streamlit:
 
    ```bash
-   streamlit run oaim_sandbox.py --server.port 8501
+   streamlit run oai_client.py --server.port 8501
    ```
 
 1. Navigate to `http://localhost:8501`.
@@ -73,13 +73,13 @@ To run the application in a container; download the [source](https://github.com/
 
    ```bash
    cd src/
-   podman build -t oaim-sandbox .
+   podman build -t oai-client .
    ```
 
 1. Start the Container:
 
    ```bash
-   podman run -p 8501:8501 -it --rm oaim-sandbox
+   podman run -p 8501:8501 -it --rm oai-client
    ```
 
 1. Navigate to `http://localhost:8501`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Oracle AI Microservices Sandbox
+# Oracle AI Explorer for Apps
 
 <!-- spell-checker:ignore streamlit, venv, oaim -->
 
@@ -6,9 +6,9 @@
 
 ## Description
 
-The **Oracle AI Microservices Sandbox** provides a streamlined environment where developers and data scientists can explore the potential of Generative Artificial Intelligence (GenAI) combined with Retrieval-Augmented Generation (RAG) capabilities. By integrating **Oracle Database 23ai** AI Vector Search, the Sandbox enables users to enhance existing Large Language Models (LLMs) through RAG.
+The **Oracle AI Explorer for Apps** provides a streamlined environment where developers and data scientists can explore the potential of Generative Artificial Intelligence (GenAI) combined with Retrieval-Augmented Generation (RAG) capabilities. By integrating **Oracle Database 23ai** AI Vector Search, the AI Explorer enables users to enhance existing Large Language Models (LLMs) through RAG.
 
-## Sandbox Features
+## AI Explorer Features
 
 - [Configuring Embedding and Chat Models](https://oracle-samples.github.io/oaim-sandbox/sandbox/configuration/model_config)
 - [Splitting and Embedding Documentation](https://oracle-samples.github.io/oaim-sandbox/sandbox/tools/split_embed)
@@ -18,7 +18,7 @@ The **Oracle AI Microservices Sandbox** provides a streamlined environment where
 
 ## Getting Started
 
-The **Oracle AI Microservices Sandbox** is available to install in your own environment, which may be a developer's desktop, on-premises data center environment, or a cloud provider. It can be run either on bare-metal, within a container, or in a Kubernetes Cluster.
+The **Oracle AI Explorer for Apps** is available to install in your own environment, which may be a developer's desktop, on-premises data center environment, or a cloud provider. It can be run either on bare-metal, within a container, or in a Kubernetes Cluster.
 
 For more information, including more details on **Setup and Configuration** please visit the [documentation](https://oracle-samples.github.io/oaim-sandbox).
 
@@ -61,7 +61,7 @@ To run the application on bare-metal; download the [source](https://github.com/o
 
 1. Navigate to `http://localhost:8501`.
 
-1. [Configure](https://oracle-samples.github.io/oaim-sandbox/sandbox/configuration) the Sandbox.
+1. [Configure](https://oracle-samples.github.io/oaim-sandbox/sandbox/configuration) the AI Explorer.
 
 #### Container Installation
 
@@ -84,7 +84,7 @@ To run the application in a container; download the [source](https://github.com/
 
 1. Navigate to `http://localhost:8501`.
 
-1. [Configure](https://oracle-samples.github.io/oaim-sandbox/sandbox/configuration/index.html) the Sandbox.
+1. [Configure](https://oracle-samples.github.io/oaim-sandbox/sandbox/configuration/index.html) the AI Explorer.
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,12 @@
-# Oracle AI Microservices Sandbox - Documentation
+# Oracle AI Explorer for Apps - Documentation
 
 ## Description
 
-This directory contains the documentation for the the [**Oracle AI Microservices Sandbox**](https://github.com/oracle-samples/oaim-sandbox).
+This directory contains the documentation for the the [**Oracle AI Explorer for Apps**](https://github.com/oracle-samples/oaim-sandbox).
 
 ## Getting Started - Documentation
 
-The **Oracle AI Microservices Sandbox** documentation is powered by [Hugo](https://gohugo.io/) using the [Relearn](https://github.com/McShelby/hugo-theme-relearn) theme.
+The **Oracle AI Explorer for Apps** documentation is powered by [Hugo](https://gohugo.io/) using the [Relearn](https://github.com/McShelby/hugo-theme-relearn) theme.
 
 To contribute to the documentation, install [Hugo](https://gohugo.io/installation/). Installation instructions vary per Operating System.
 

--- a/docs/content/advanced/_index.md
+++ b/docs/content/advanced/_index.md
@@ -7,6 +7,6 @@ Copyright (c) 2024, 2025, Oracle and/or its affiliates.
 Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 -->
 
-There is a lot more you can do with the {{ .Site.Params.LongName | markdownify }}.  Explore some of the more Advanced capabilities here:
+There is a lot more you can do with the **{{< param "LongName" >}}**.  Explore some of the more Advanced capabilities here:
 
 {{% children %}}

--- a/docs/content/advanced/_index.md
+++ b/docs/content/advanced/_index.md
@@ -7,6 +7,6 @@ Copyright (c) 2024, 2025, Oracle and/or its affiliates.
 Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 -->
 
-There is a lot more you can do with the Oracle AI Microservices Sandbox.  Explore some of the more Advanced capabilities here:
+There is a lot more you can do with the {{ .Site.Params.LongName | markdownify }}.  Explore some of the more Advanced capabilities here:
 
 {{% children %}}

--- a/docs/content/advanced/microservices.md
+++ b/docs/content/advanced/microservices.md
@@ -10,11 +10,11 @@ Licensed under the Universal Permissive License v1.0 as shown at http://oss.orac
 spell-checker: ignore opentofu ocid oraclecloud oaim  ollama crds ADBDB finalizers mxbai sandboxdb
 -->
 
-The {{ .Site.Params.LongName | markdownify }} (the {{ .Site.Params.ShortName | markdownify }}) was specifically designed to run on infrastructure supporting microservices architecture, including [Kubernetes](https://kubernetes.io/).
+The **{{< param "LongName" >}}** (the **{{< param "ShortName" >}}**) was specifically designed to run on infrastructure supporting microservices architecture, including [Kubernetes](https://kubernetes.io/).
 
 ## Oracle Kubernetes Engine
 
-The following example shows running the {{ .Site.Params.ShortName | markdownify }} in [Oracle Kubernetes Engine](https://docs.oracle.com/en-us/iaas/Content/ContEng/Concepts/contengoverview.htm) (**OKE**).  The Infrastructure as Code (**IaC**) provided in the source [opentofu](https://github.com/oracle-samples/oaim-sandbox/tree/main/opentofu) directory was used to provision the infrastructure in Oracle Cloud Infrastructure (**OCI**).
+The following example shows running the **{{< param "ShortName" >}}** in [Oracle Kubernetes Engine](https://docs.oracle.com/en-us/iaas/Content/ContEng/Concepts/contengoverview.htm) (**OKE**).  The Infrastructure as Code (**IaC**) provided in the source [opentofu](https://github.com/oracle-samples/oaim-sandbox/tree/main/opentofu) directory was used to provision the infrastructure in Oracle Cloud Infrastructure (**OCI**).
 
 ![OCI OKE](../images/infra_oci.png)
 
@@ -22,9 +22,9 @@ The command to connect to the **OKE** cluster will be output as part of the **Ia
 
 ### Ingress
 
-To access the {{ .Site.Params.ShortName | markdownify }} GUI and API Server, you can either use a port-forward or an Ingress service.  For demonstration purposes, the [Ingress-Nginx Controller](https://kubernetes.github.io/ingress-nginx/deploy/) will be used to create a [Flexible LoadBalancer](https://docs.oracle.com/en-us/iaas/Content/NetworkLoadBalancer/overview.htm) in **OCI**.
+To access the **{{< param "ShortName" >}}** GUI and API Server, you can either use a port-forward or an Ingress service.  For demonstration purposes, the [Ingress-Nginx Controller](https://kubernetes.github.io/ingress-nginx/deploy/) will be used to create a [Flexible LoadBalancer](https://docs.oracle.com/en-us/iaas/Content/NetworkLoadBalancer/overview.htm) in **OCI**.
 
-This example will create the loadbalancer exposing port 80 for the {{ .Site.Params.ShortName | markdownify }} GUI and port 8000 for the {{ .Site.Params.ShortName | markdownify }} API Server.  It is _HIGHLY_ recommended to protect these ports with [Network Security Groups](https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/networksecuritygroups.htm)(**NSG**).
+This example will create the loadbalancer exposing port 80 for the **{{< param "ShortName" >}}** GUI and port 8000 for the **{{< param "ShortName" >}}** API Server.  It is _HIGHLY_ recommended to protect these ports with [Network Security Groups](https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/networksecuritygroups.htm)(**NSG**).
 
 The service manifest has two values that should be supplied:
 
@@ -106,9 +106,9 @@ These will be output as part of the **IaC** but can be removed from the code if 
 
 ### Images
 
-You will need to build the {{ .Site.Params.ShortName | markdownify }} container images and stage them in a container registry, such as the [OCI Container Registry](https://docs.oracle.com/en-us/iaas/Content/Registry/Concepts/registryoverview.htm) (**OCIR**).
+You will need to build the **{{< param "ShortName" >}}** container images and stage them in a container registry, such as the [OCI Container Registry](https://docs.oracle.com/en-us/iaas/Content/Registry/Concepts/registryoverview.htm) (**OCIR**).
 
-1. Build the {{ .Site.Params.ShortName | markdownify }} images:
+1. Build the **{{< param "ShortName" >}}** images:
 
     From the code source `src/` directory:
     ```bash
@@ -132,7 +132,7 @@ You will need to build the {{ .Site.Params.ShortName | markdownify }} container 
 
     You will be prompted for a username and token password.
 
-1. Push the {{ .Site.Params.ShortName | markdownify }} images:
+1. Push the **{{< param "ShortName" >}}** images:
 
     More information on pushing images to **OCIR** can be found [here](https://docs.oracle.com/en-us/iaas/Content/Registry/Tasks/registrypushingimagesusingthedockercli.htm).
 
@@ -145,10 +145,10 @@ You will need to build the {{ .Site.Params.ShortName | markdownify }} container 
     podman push <server_repository>:latest
     ```
 
-### {{ .Site.Params.LongName | markdownify }}
+### **{{< param "LongName" >}}**
 
-The {{ .Site.Params.ShortName | markdownify }} can be deployed using the [Helm](https://helm.sh/) chart provided with the source:
-[{{ .Site.Params.ShortName | markdownify }} Helm Chart](https://github.com/oracle-samples/oaim-sandbox/tree/main/helm).  A list of all values can be found in [values_summary.md](https://github.com/oracle-samples/oaim-sandbox/tree/main/helm/values_summary.md).
+The **{{< param "ShortName" >}}** can be deployed using the [Helm](https://helm.sh/) chart provided with the source:
+[**{{< param "ShortName" >}}** Helm Chart](https://github.com/oracle-samples/oaim-sandbox/tree/main/helm).  A list of all values can be found in [values_summary.md](https://github.com/oracle-samples/oaim-sandbox/tree/main/helm/values_summary.md).
 
 If you deployed a GPU node pool as part of the **IaC**, you can deploy Ollama and enable a Large Language and Embedding Model out-of-the-box.
 
@@ -192,7 +192,7 @@ If you deployed a GPU node pool as part of the **IaC**, you can deploy Ollama an
 
     - `<lb_reserved_ip>` - A reserved IP address for the Loadbalancer
     - `<adb_ocid>` - Autonomous Database OCID
-    - `<sandbox_repository>` - Full path to the repository for the {{ .Site.Params.ShortName | markdownify }} Image 
+    - `<sandbox_repository>` - Full path to the repository for the **{{< param "ShortName" >}}** Image 
     - `<server_repository>` - Full path to the repository for the API Server Image
 
     These will be output as part of the **IaC**.
@@ -268,7 +268,7 @@ If you deployed a GPU node pool as part of the **IaC**, you can deploy Ollama an
 
 ### Cleanup
 
-To remove the {{ .Site.Params.ShortName | markdownify }} from the OKE Cluster:
+To remove the **{{< param "ShortName" >}}** from the OKE Cluster:
 
 1. Uninstall the Helm Chart:
 

--- a/docs/content/advanced/microservices.md
+++ b/docs/content/advanced/microservices.md
@@ -10,11 +10,11 @@ Licensed under the Universal Permissive License v1.0 as shown at http://oss.orac
 spell-checker: ignore opentofu ocid oraclecloud oaim  ollama crds ADBDB finalizers mxbai sandboxdb
 -->
 
-The Oracle AI Microservices Sandbox (the **Sandbox**) was specifically designed to run on infrastructure supporting microservices architecture, including [Kubernetes](https://kubernetes.io/).
+The {{ .Site.Params.LongName | markdownify }} (the {{ .Site.Params.ShortName | markdownify }}) was specifically designed to run on infrastructure supporting microservices architecture, including [Kubernetes](https://kubernetes.io/).
 
 ## Oracle Kubernetes Engine
 
-The following example shows running the **Sandbox** in [Oracle Kubernetes Engine](https://docs.oracle.com/en-us/iaas/Content/ContEng/Concepts/contengoverview.htm) (**OKE**).  The Infrastructure as Code (**IaC**) provided in the source [opentofu](https://github.com/oracle-samples/oaim-sandbox/tree/main/opentofu) directory was used to provision the infrastructure in Oracle Cloud Infrastructure (**OCI**).
+The following example shows running the {{ .Site.Params.ShortName | markdownify }} in [Oracle Kubernetes Engine](https://docs.oracle.com/en-us/iaas/Content/ContEng/Concepts/contengoverview.htm) (**OKE**).  The Infrastructure as Code (**IaC**) provided in the source [opentofu](https://github.com/oracle-samples/oaim-sandbox/tree/main/opentofu) directory was used to provision the infrastructure in Oracle Cloud Infrastructure (**OCI**).
 
 ![OCI OKE](../images/infra_oci.png)
 
@@ -22,9 +22,9 @@ The command to connect to the **OKE** cluster will be output as part of the **Ia
 
 ### Ingress
 
-To access the Sandbox GUI and API Server, you can either use a port-forward or an Ingress service.  For demonstration purposes, the [Ingress-Nginx Controller](https://kubernetes.github.io/ingress-nginx/deploy/) will be used to create a [Flexible LoadBalancer](https://docs.oracle.com/en-us/iaas/Content/NetworkLoadBalancer/overview.htm) in **OCI**.
+To access the {{ .Site.Params.ShortName | markdownify }} GUI and API Server, you can either use a port-forward or an Ingress service.  For demonstration purposes, the [Ingress-Nginx Controller](https://kubernetes.github.io/ingress-nginx/deploy/) will be used to create a [Flexible LoadBalancer](https://docs.oracle.com/en-us/iaas/Content/NetworkLoadBalancer/overview.htm) in **OCI**.
 
-This example will create the loadbalancer exposing port 80 for the Sandbox GUI and port 8000 for the Sandbox API Server.  It is _HIGHLY_ recommended to protect these ports with [Network Security Groups](https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/networksecuritygroups.htm)(**NSG**).
+This example will create the loadbalancer exposing port 80 for the {{ .Site.Params.ShortName | markdownify }} GUI and port 8000 for the {{ .Site.Params.ShortName | markdownify }} API Server.  It is _HIGHLY_ recommended to protect these ports with [Network Security Groups](https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/networksecuritygroups.htm)(**NSG**).
 
 The service manifest has two values that should be supplied:
 
@@ -106,9 +106,9 @@ These will be output as part of the **IaC** but can be removed from the code if 
 
 ### Images
 
-You will need to build the **Sandbox** container images and stage them in a container registry, such as the [OCI Container Registry](https://docs.oracle.com/en-us/iaas/Content/Registry/Concepts/registryoverview.htm) (**OCIR**).
+You will need to build the {{ .Site.Params.ShortName | markdownify }} container images and stage them in a container registry, such as the [OCI Container Registry](https://docs.oracle.com/en-us/iaas/Content/Registry/Concepts/registryoverview.htm) (**OCIR**).
 
-1. Build the **Sandbox** images:
+1. Build the {{ .Site.Params.ShortName | markdownify }} images:
 
     From the code source `src/` directory:
     ```bash
@@ -132,7 +132,7 @@ You will need to build the **Sandbox** container images and stage them in a cont
 
     You will be prompted for a username and token password.
 
-1. Push the **Sandbox** images:
+1. Push the {{ .Site.Params.ShortName | markdownify }} images:
 
     More information on pushing images to **OCIR** can be found [here](https://docs.oracle.com/en-us/iaas/Content/Registry/Tasks/registrypushingimagesusingthedockercli.htm).
 
@@ -145,25 +145,25 @@ You will need to build the **Sandbox** container images and stage them in a cont
     podman push <server_repository>:latest
     ```
 
-### Oracle AI Microservices Sandbox
+### {{ .Site.Params.LongName | markdownify }}
 
-The **Sandbox** can be deployed using the [Helm](https://helm.sh/) chart provided with the source:
-[**Sandbox** Helm Chart](https://github.com/oracle-samples/oaim-sandbox/tree/main/helm).  A list of all values can be found in [values_summary.md](https://github.com/oracle-samples/oaim-sandbox/tree/main/helm/values_summary.md).
+The {{ .Site.Params.ShortName | markdownify }} can be deployed using the [Helm](https://helm.sh/) chart provided with the source:
+[{{ .Site.Params.ShortName | markdownify }} Helm Chart](https://github.com/oracle-samples/oaim-sandbox/tree/main/helm).  A list of all values can be found in [values_summary.md](https://github.com/oracle-samples/oaim-sandbox/tree/main/helm/values_summary.md).
 
 If you deployed a GPU node pool as part of the **IaC**, you can deploy Ollama and enable a Large Language and Embedding Model out-of-the-box.
 
-1. Create the `oaim-sandbox` namespace:
+1. Create the `oai-client` namespace:
     
     ```bash
-    kubectl create namespace oaim-sandbox
+    kubectl create namespace oai-client
     ```
 
 1. Create a secret to hold the API Key:
 
     ```bash
-    kubectl create secret generic sandbox-api-key \
+    kubectl create secret generic client-api-key \
       --from-literal=apiKey=$(openssl rand -hex 32) \
-      --namespace=oaim-sandbox
+      --namespace=oai-client
     ```
 
 1. Create a secret to hold the Database Authentication:
@@ -192,7 +192,7 @@ If you deployed a GPU node pool as part of the **IaC**, you can deploy Ollama an
 
     - `<lb_reserved_ip>` - A reserved IP address for the Loadbalancer
     - `<adb_ocid>` - Autonomous Database OCID
-    - `<sandbox_repository>` - Full path to the repository for the Sandbox Image 
+    - `<sandbox_repository>` - Full path to the repository for the {{ .Site.Params.ShortName | markdownify }} Image 
     - `<server_repository>` - Full path to the repository for the API Server Image
 
     These will be output as part of the **IaC**.
@@ -268,7 +268,7 @@ If you deployed a GPU node pool as part of the **IaC**, you can deploy Ollama an
 
 ### Cleanup
 
-To remove the **Sandbox** from the OKE Cluster:
+To remove the {{ .Site.Params.ShortName | markdownify }} from the OKE Cluster:
 
 1. Uninstall the Helm Chart:
 

--- a/docs/content/advanced/springai.md
+++ b/docs/content/advanced/springai.md
@@ -29,7 +29,7 @@ You have simply to:
 chmod 755 ./env.sh
 ```
 
-* add the password for the user used to connect from the OAIM Sandbox to the Oracle DB23ai used as vectorstore: 
+* add the password for the user used to connect from the {{ .Site.Params.LongName | markdownify }} to the Oracle DB23ai used as vectorstore: 
 
 ```bash
 export DB_PASSWORD=""
@@ -112,7 +112,7 @@ llama3.1:latest             a80c4f17acd5    2.0 GB    3 minutes ago
 kubectl -n ollama exec svc/ollama -- ollama run "llama3.1" "what is spring boot?"
 ```
 
-**NOTICE**: The Microservices will access to the ADB23ai on which the vector store table should be created, as done in the local desktop example shown before. To access the OAIM-Sandbox running on **Oracle Backend for Microservices and AI** and create the same configuration, let’s do:
+**NOTICE**: The Microservices will access to the ADB23ai on which the vector store table should be created, as done in the local desktop example shown before. To access the {{ .Site.Params.LongName | markdownify }} running on **Oracle Backend for Microservices and AI** and create the same configuration, let’s do:
 
 * tunnel:
 
@@ -137,7 +137,7 @@ oractl:> create --app-name rag
 oractl:> bind --app-name rag --service-name myspringai --username vector
 ```
 
-The `bind` will create the new user, if not exists, but to have the `SPRING_AI_VECTORS` table compatible with SpringAI Oracle vector store adapter, the microservices needs to access to the vector store table created by the OAIM-sandbox with user ADMIN on ADB, for example:
+The `bind` will create the new user, if not exists, but to have the `SPRING_AI_VECTORS` table compatible with SpringAI Oracle vector store adapter, the microservices needs to access to the vector store table created by the {{ .Site.Params.LongName | markdownify }} with user ADMIN on ADB, for example:
 
 ```sql
 GRANT SELECT ON ADMIN.MXBAI_EMBED_LARGE_512_103_COSINE TO vector;

--- a/docs/content/help/troubleshooting/_index.md
+++ b/docs/content/help/troubleshooting/_index.md
@@ -10,10 +10,10 @@ Licensed under the Universal Permissive License v1.0 as shown at http://oss.orac
 ## Startup Time
 
 **_Problem_**:
-After starting the {{ .Site.Params.ShortName | markdownify }}, it takes a long time to load the first page.
+After starting the **{{< param "ShortName" >}}**, it takes a long time to load the first page.
 
 **_Solution_**:
-This is normally the result of a configured database that is inaccessible. Depending on how you've configured the database, if `retry_count`, and `retry_delay` is set but the database is inaccessible, the {{ .Site.Params.ShortName | markdownify }} will appear to hang for the duration of `retry_count * retry_delay` during the startup.
+This is normally the result of a configured database that is inaccessible. Depending on how you've configured the database, if `retry_count`, and `retry_delay` is set but the database is inaccessible, the **{{< param "ShortName" >}}** will appear to hang for the duration of `retry_count * retry_delay` during the startup.
 
 ## Embedding Rate Limits
 

--- a/docs/content/help/troubleshooting/_index.md
+++ b/docs/content/help/troubleshooting/_index.md
@@ -10,10 +10,10 @@ Licensed under the Universal Permissive License v1.0 as shown at http://oss.orac
 ## Startup Time
 
 **_Problem_**:
-After starting the **Sandbox**, it takes a long time to load the first page.
+After starting the {{ .Site.Params.ShortName | markdownify }}, it takes a long time to load the first page.
 
 **_Solution_**:
-This is normally the result of a configured database that is inaccessible. Depending on how you've configured the database, if `retry_count`, and `retry_delay` is set but the database is inaccessible, the **Sandbox** will appear to hang for the duration of `retry_count * retry_delay` during the startup.
+This is normally the result of a configured database that is inaccessible. Depending on how you've configured the database, if `retry_count`, and `retry_delay` is set but the database is inaccessible, the {{ .Site.Params.ShortName | markdownify }} will appear to hang for the duration of `retry_count * retry_delay` during the startup.
 
 ## Embedding Rate Limits
 

--- a/docs/content/sandbox/_index.md
+++ b/docs/content/sandbox/_index.md
@@ -1,5 +1,5 @@
 +++
-title = 'The {{ .Site.Params.ShortName | markdownify }}'
+title = 'The AI Explorer'
 weight = 20
 +++
 
@@ -10,23 +10,23 @@ Licensed under the Universal Permissive License v1.0 as shown at http://oss.orac
 spell-checker:ignore streamlit, oaim, uvicorn
 -->
 
-The {{ .Site.Params.LongName | markdownify }} (the {{ .Site.Params.ShortName | markdownify }}) consists of an API Server ([**oaim-server**](#api-server-oaim-server)) and an _optional_ web-based GUI ([**oai-client**](#client-oai-client)) component.  Both the API Server and GUI can be run on bare-metal or inside containers.  
+The **{{< param "LongName" >}}** (the **{{< param "ShortName" >}}**) consists of an API Server ([**oaim-server**](#api-server-oaim-server)) and an _optional_ web-based GUI ([**oai-client**](#client-oai-client)) component.  Both the API Server and GUI can be run on bare-metal or inside containers.  
 
 ![Architecture Overview](images/arch_overview.png)
 
-The following additional components, not delivered with the {{ .Site.Params.ShortName | markdownify }}, are also required.  These can be run On-Premises or in the Cloud:
+The following additional components, not delivered with the **{{< param "ShortName" >}}**, are also required.  These can be run On-Premises or in the Cloud:
 - [Oracle Database 23ai](#database), including [Oracle Database 23ai **Free**](https://www.oracle.com/uk/database/free/)
 - Access to at least one [Large Language Model](#large-language-model)
 - Access to at least one [Embedding Model](#embedding-model) (for Retrieval Augmented Generation)
 
-The {{ .Site.Params.ShortName | markdownify }} is specifically designed to run in container orchestration systems, such as [Kubernetes](https://kubernetes.io/).  For more information on deploying the {{ .Site.Params.ShortName | markdownify }} in Kubernetes, using a Helm Chart, please review the [Advanced - Microservices](../advanced/microservices) documentation.
+The **{{< param "ShortName" >}}** is specifically designed to run in container orchestration systems, such as [Kubernetes](https://kubernetes.io/).  For more information on deploying the **{{< param "ShortName" >}}** in Kubernetes, using a Helm Chart, please review the [Advanced - Microservices](../advanced/microservices) documentation.
 
-## API Server (OAIM Server)
+## API Server (OAI Server)
 
-The workhorse of the {{ .Site.Params.ShortName | markdownify }} is the API Server, referred to as the **OAIM Server**.  By default, the **OAIM Server** will start on port 8000
+The workhorse of the **{{< param "ShortName" >}}** is the API Server, referred to as the **OAI Server**.  By default, the **OAI Server** will start on port 8000
 
 {{% notice style="code" title="All the docs" icon="circle-info" %}}
-The **OAIM Server** API documentation can be accessed at `http://<IP Address>:<Port>/v1/docs#` of a running instance. 
+The **OAI Server** API documentation can be accessed at `http://<IP Address>:<Port>/v1/docs#` of a running instance. 
 {{% /notice %}}
 
 ![API Server](images/api_server.png)
@@ -45,19 +45,19 @@ You can develop and replace the provided client with any REST capable client.
 
 ## Database
 
-[Oracle Database 23ai](https://www.oracle.com/uk/database/23ai/), including [Oracle Database 23ai **Free**](https://www.oracle.com/uk/database/free/) provides a persistent data store for the {{ .Site.Params.ShortName | markdownify }}.  
+[Oracle Database 23ai](https://www.oracle.com/uk/database/23ai/), including [Oracle Database 23ai **Free**](https://www.oracle.com/uk/database/free/) provides a persistent data store for the **{{< param "ShortName" >}}**.  
 
 ![Database](images/vector_storage.png)
 
 {{% notice style="code" title="Reduced capabilities" icon="circle-info" %}}
-The {{ .Site.Params.ShortName | markdownify }} can be used to interact with language models without having the database configured, but additional functionality such as RAG, will not be available without the database.
+The **{{< param "ShortName" >}}** can be used to interact with language models without having the database configured, but additional functionality such as RAG, will not be available without the database.
 {{% /notice %}}
 
 The 23ai database provides:
 
 - the Vector Store for split and embedded documents used for Retrieval Augmented Generation (RAG).
 - storage for the [Testbed](testbed) Q&A Test Sets and Evaluations
-- storage of {{ .Site.Params.ShortName | markdownify }} settings and configuration
+- storage of **{{< param "ShortName" >}}** settings and configuration
 
 ## Document Source
 
@@ -65,4 +65,4 @@ Access to document sources for the purpose of embedding and populating the Vecto
 
 ## AI Models
 
-The {{ .Site.Params.ShortName | markdownify }} provides the ability to connect to any language or embedding model to be used for completions and creating vectors.  Adding, Deleting, and Modifying access to AI Models is quick and easy.
+The **{{< param "ShortName" >}}** provides the ability to connect to any language or embedding model to be used for completions and creating vectors.  Adding, Deleting, and Modifying access to AI Models is quick and easy.

--- a/docs/content/sandbox/_index.md
+++ b/docs/content/sandbox/_index.md
@@ -1,5 +1,5 @@
 +++
-title = 'The Sandbox'
+title = 'The {{ .Site.Params.ShortName | markdownify }}'
 weight = 20
 +++
 
@@ -10,20 +10,20 @@ Licensed under the Universal Permissive License v1.0 as shown at http://oss.orac
 spell-checker:ignore streamlit, oaim, uvicorn
 -->
 
-The **Oracle AI Microservices Sandbox** (the **Sandbox**) consists of an API Server ([**oaim-server**](#api-server-oaim-server)) and an _optional_ web-based GUI ([**oaim-sandbox**](#client-oaim-sandbox)) component.  Both the API Server and GUI can be run on bare-metal or inside containers.  
+The {{ .Site.Params.LongName | markdownify }} (the {{ .Site.Params.ShortName | markdownify }}) consists of an API Server ([**oaim-server**](#api-server-oaim-server)) and an _optional_ web-based GUI ([**oai-client**](#client-oai-client)) component.  Both the API Server and GUI can be run on bare-metal or inside containers.  
 
 ![Architecture Overview](images/arch_overview.png)
 
-The following additional components, not delivered with the **Sandbox**, are also required.  These can be run On-Premises or in the Cloud:
+The following additional components, not delivered with the {{ .Site.Params.ShortName | markdownify }}, are also required.  These can be run On-Premises or in the Cloud:
 - [Oracle Database 23ai](#database), including [Oracle Database 23ai **Free**](https://www.oracle.com/uk/database/free/)
 - Access to at least one [Large Language Model](#large-language-model)
 - Access to at least one [Embedding Model](#embedding-model) (for Retrieval Augmented Generation)
 
-The **Sandbox** is specifically designed to run in container orchestration systems, such as [Kubernetes](https://kubernetes.io/).  For more information on deploying the **Sandbox** in Kubernetes, using a Helm Chart, please review the [Advanced - Microservices](../advanced/microservices) documentation.
+The {{ .Site.Params.ShortName | markdownify }} is specifically designed to run in container orchestration systems, such as [Kubernetes](https://kubernetes.io/).  For more information on deploying the {{ .Site.Params.ShortName | markdownify }} in Kubernetes, using a Helm Chart, please review the [Advanced - Microservices](../advanced/microservices) documentation.
 
 ## API Server (OAIM Server)
 
-The workhorse of the **Sandbox** is the API Server, referred to as the **OAIM Server**.  By default, the **OAIM Server** will start on port 8000
+The workhorse of the {{ .Site.Params.ShortName | markdownify }} is the API Server, referred to as the **OAIM Server**.  By default, the **OAIM Server** will start on port 8000
 
 {{% notice style="code" title="All the docs" icon="circle-info" %}}
 The **OAIM Server** API documentation can be accessed at `http://<IP Address>:<Port>/v1/docs#` of a running instance. 
@@ -33,7 +33,7 @@ The **OAIM Server** API documentation can be accessed at `http://<IP Address>:<P
 
 Powered by [FastAPI](https://fastapi.tiangolo.com/) and [Uvicorn](https://www.uvicorn.org/), the **OAIM Server** acts as an intermediary between the clients, AI Models, and the Oracle Database.
 
-## Client (OAIM Sandbox)
+## Client (OAI Client)
 
 The provided web-based GUI client is built with [Streamlit](https://streamlit.io/) and interacts with the API Server via REST calls.  
 
@@ -45,19 +45,19 @@ You can develop and replace the provided client with any REST capable client.
 
 ## Database
 
-[Oracle Database 23ai](https://www.oracle.com/uk/database/23ai/), including [Oracle Database 23ai **Free**](https://www.oracle.com/uk/database/free/) provides a persistent data store for the **Sandbox**.  
+[Oracle Database 23ai](https://www.oracle.com/uk/database/23ai/), including [Oracle Database 23ai **Free**](https://www.oracle.com/uk/database/free/) provides a persistent data store for the {{ .Site.Params.ShortName | markdownify }}.  
 
 ![Database](images/vector_storage.png)
 
 {{% notice style="code" title="Reduced capabilities" icon="circle-info" %}}
-The **Sandbox** can be used to interact with language models without having the database configured, but additional functionality such as RAG, will not be available without the database.
+The {{ .Site.Params.ShortName | markdownify }} can be used to interact with language models without having the database configured, but additional functionality such as RAG, will not be available without the database.
 {{% /notice %}}
 
 The 23ai database provides:
 
 - the Vector Store for split and embedded documents used for Retrieval Augmented Generation (RAG).
 - storage for the [Testbed](testbed) Q&A Test Sets and Evaluations
-- storage of **Sandbox** settings and configuration
+- storage of {{ .Site.Params.ShortName | markdownify }} settings and configuration
 
 ## Document Source
 
@@ -65,4 +65,4 @@ Access to document sources for the purpose of embedding and populating the Vecto
 
 ## AI Models
 
-The **Sandbox** provides the ability to connect to any language or embedding model to be used for completions and creating vectors.  Adding, Deleting, and Modifying access to AI Models is quick and easy.
+The {{ .Site.Params.ShortName | markdownify }} provides the ability to connect to any language or embedding model to be used for completions and creating vectors.  Adding, Deleting, and Modifying access to AI Models is quick and easy.

--- a/docs/content/sandbox/api_server/_index.md
+++ b/docs/content/sandbox/api_server/_index.md
@@ -7,19 +7,19 @@ Copyright (c) 2024, 2025, Oracle and/or its affiliates.
 Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 -->
 
-The {{ .Site.Params.LongName | markdownify }} (the {{ .Site.Params.ShortName | markdownify }}) is powered by an API Server to allow for any client to access its features.  The API Server can be run as part of the provided {{ .Site.Params.ShortName | markdownify }} GUI client or as a separate, independent process.  
+The **{{< param "LongName" >}}** (the **{{< param "ShortName" >}}**) is powered by an API Server to allow for any client to access its features.  The API Server can be run as part of the provided **{{< param "ShortName" >}}** GUI client or as a separate, independent process.  
 
-Each client connected to the API Server, including those from the {{ .Site.Params.ShortName | markdownify }} GUI client, share the same configuration but maintain their own settings.  Database, Model, OCI, and Prompt configurations are used across all clients; but which database, models, OCI profile, and prompts set are specific to each client.
+Each client connected to the API Server, including those from the **{{< param "ShortName" >}}** GUI client, share the same configuration but maintain their own settings.  Database, Model, OCI, and Prompt configurations are used across all clients; but which database, models, OCI profile, and prompts set are specific to each client.
 
-When started as part of the {{ .Site.Params.ShortName | markdownify }} client, you can change the Port it listens on and the API Server Key.  A restart is required for the changes to take effect.
+When started as part of the **{{< param "ShortName" >}}** client, you can change the Port it listens on and the API Server Key.  A restart is required for the changes to take effect.
 
 ![Server Configuration](images/api_server_config.png)
 
-If the API Server is started independently of the {{ .Site.Params.ShortName | markdownify }} client, the configuration is shown, but cannot be modified from the client.
+If the API Server is started independently of the **{{< param "ShortName" >}}** client, the configuration is shown, but cannot be modified from the client.
 
 ## Server Configuration
 
-During the startup of the API Server, a `server` client is created and populated with minimal settings.  The `server` client is the default when calling the API Server outside of the {{ .Site.Params.ShortName | markdownify }} GUI client.  To copy your {{ .Site.Params.ShortName | markdownify }} GUI client settings to the `server` client for use with external application clients, click the "Copy AI Explorer Settings".  
+During the startup of the API Server, a `server` client is created and populated with minimal settings.  The `server` client is the default when calling the API Server outside of the **{{< param "ShortName" >}}** GUI client.  To copy your **{{< param "ShortName" >}}** GUI client settings to the `server` client for use with external application clients, click the "Copy AI Explorer Settings".  
 
 ![Server Settings](images/api_server_settings.png)
 
@@ -27,6 +27,6 @@ You can review how the `server` client is configured by expanding the `{...}` br
 
 ## Server Activity
 
-All interactions with the API Server using the `server` client can be seen in the Server Activity.  Toggle the "Auto Refresh" or manually refresh the Activity to see interactions from outside the {{ .Site.Params.ShortName | markdownify }} GUI client.
+All interactions with the API Server using the `server` client can be seen in the Server Activity.  Toggle the "Auto Refresh" or manually refresh the Activity to see interactions from outside the **{{< param "ShortName" >}}** GUI client.
 
 ![Server Settings](images/api_server_activity.png)

--- a/docs/content/sandbox/api_server/_index.md
+++ b/docs/content/sandbox/api_server/_index.md
@@ -7,19 +7,19 @@ Copyright (c) 2024, 2025, Oracle and/or its affiliates.
 Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 -->
 
-The **Oracle AI Microservices Sandbox** (the **Sandbox**) is powered by an API Server to allow for any client to access its features.  The API Server can be run as part of the provided **Sandbox** GUI client or as a separate, independent process.  
+The {{ .Site.Params.LongName | markdownify }} (the {{ .Site.Params.ShortName | markdownify }}) is powered by an API Server to allow for any client to access its features.  The API Server can be run as part of the provided {{ .Site.Params.ShortName | markdownify }} GUI client or as a separate, independent process.  
 
-Each client connected to the API Server, including those from the **Sandbox** GUI client, share the same configuration but maintain their own settings.  Database, Model, OCI, and Prompt configurations are used across all clients; but which database, models, OCI profile, and prompts set are specific to each client.
+Each client connected to the API Server, including those from the {{ .Site.Params.ShortName | markdownify }} GUI client, share the same configuration but maintain their own settings.  Database, Model, OCI, and Prompt configurations are used across all clients; but which database, models, OCI profile, and prompts set are specific to each client.
 
-When started as part of the **Sandbox** client, you can change the Port it listens on and the API Server Key.  A restart is required for the changes to take effect.
+When started as part of the {{ .Site.Params.ShortName | markdownify }} client, you can change the Port it listens on and the API Server Key.  A restart is required for the changes to take effect.
 
 ![Server Configuration](images/api_server_config.png)
 
-If the API Server is started independently of the **Sandbox** client, the configuration is shown, but cannot be modified from the client.
+If the API Server is started independently of the {{ .Site.Params.ShortName | markdownify }} client, the configuration is shown, but cannot be modified from the client.
 
 ## Server Configuration
 
-During the startup of the API Server, a `server` client is created and populated with minimal settings.  The `server` client is the default when calling the API Server outside of the **Sandbox** GUI client.  To copy your **Sandbox** GUI client settings to the `server` client for use with external application clients, click the "Copy Sandbox Settings".  
+During the startup of the API Server, a `server` client is created and populated with minimal settings.  The `server` client is the default when calling the API Server outside of the {{ .Site.Params.ShortName | markdownify }} GUI client.  To copy your {{ .Site.Params.ShortName | markdownify }} GUI client settings to the `server` client for use with external application clients, click the "Copy AI Explorer Settings".  
 
 ![Server Settings](images/api_server_settings.png)
 
@@ -27,6 +27,6 @@ You can review how the `server` client is configured by expanding the `{...}` br
 
 ## Server Activity
 
-All interactions with the API Server using the `server` client can be seen in the Server Activity.  Toggle the "Auto Refresh" or manually refresh the Activity to see interactions from outside the **Sandbox** GUI client.
+All interactions with the API Server using the `server` client can be seen in the Server Activity.  Toggle the "Auto Refresh" or manually refresh the Activity to see interactions from outside the {{ .Site.Params.ShortName | markdownify }} GUI client.
 
 ![Server Settings](images/api_server_activity.png)

--- a/docs/content/sandbox/chatbot/_index.md
+++ b/docs/content/sandbox/chatbot/_index.md
@@ -7,7 +7,7 @@ Copyright (c) 2024, 2025, Oracle and/or its affiliates.
 Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 -->
 
-The {{ .Site.Params.LongName | markdownify }} (the {{ .Site.Params.ShortName | markdownify }}) provides a Chatbot to experiment with different Language settings and Embeddings.  It allows you to manually find the optimal configuration for your AI project before launching it into Production. 
+The **{{< param "LongName" >}}** (the **{{< param "ShortName" >}}**) provides a Chatbot to experiment with different Language settings and Embeddings.  It allows you to manually find the optimal configuration for your AI project before launching it into Production. 
 
 There are a number of configurations you can experiment with to explore AI and RAG capabilities to understand their behavior without requiring deep technical knowledge.
 

--- a/docs/content/sandbox/chatbot/_index.md
+++ b/docs/content/sandbox/chatbot/_index.md
@@ -7,7 +7,7 @@ Copyright (c) 2024, 2025, Oracle and/or its affiliates.
 Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 -->
 
-The **Oracle AI Microservices Sandbox** (the **Sandbox**) provides a Chatbot to experiment with different Language settings and Embeddings.  It allows you to manually find the optimal configuration for your AI project before launching it into Production. 
+The {{ .Site.Params.LongName | markdownify }} (the {{ .Site.Params.ShortName | markdownify }}) provides a Chatbot to experiment with different Language settings and Embeddings.  It allows you to manually find the optimal configuration for your AI project before launching it into Production. 
 
 There are a number of configurations you can experiment with to explore AI and RAG capabilities to understand their behavior without requiring deep technical knowledge.
 

--- a/docs/content/sandbox/configuration/_index.md
+++ b/docs/content/sandbox/configuration/_index.md
@@ -9,13 +9,13 @@ Copyright (c) 2024, 2025, Oracle and/or its affiliates.
 Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 -->
 
-The **Oracle AI Microservices Sandbox** is not configured out-of-the-box. To enable functionality, an embedding model, language model, database, and optionally, Oracle Cloud Infrastructure (OCI) will need to be configured.
+The {{ .Site.Params.LongName | markdownify }} is not configured out-of-the-box. To enable functionality, an embedding model, language model, database, and optionally, Oracle Cloud Infrastructure (OCI) will need to be configured.
 
-Once you have configured the Sandbox, the settings can be exported to be imported into another deployment or after a restart.
+Once you have configured the {{ .Site.Params.ShortName | markdownify }}, the settings can be exported to be imported into another deployment or after a restart.
 
 ## 🤖 Model Configuration
 
-At a minimum, a large language model (LLM) will need to be configured to experiment with the **Oracle AI Microservices Sandbox**. The LLM can be a third-party LLM, such as ChatGPT or Perplexity, or an on-premises LLM.
+At a minimum, a large language model (LLM) will need to be configured to experiment with the {{ .Site.Params.LongName | markdownify }}. The LLM can be a third-party LLM, such as ChatGPT or Perplexity, or an on-premises LLM.
 
 Additionally, to enable Retrieval-Augmented Generation (RAG) capabilities, an embedding model will need to be configured and enabled.
 
@@ -39,6 +39,6 @@ For more information on configuring OCI, please read about [OCI Configuration](o
 
 ## 💾 Settings
 
-Once you have configured the **Oracle AI Microservices Sandbox**, you can export the settings and import them after a restart or new deployment.
+Once you have configured the {{ .Site.Params.LongName | markdownify }}, you can export the settings and import them after a restart or new deployment.
 
 For more information on importing (and exporting) settings, please read about [Settings](settings/).

--- a/docs/content/sandbox/configuration/_index.md
+++ b/docs/content/sandbox/configuration/_index.md
@@ -9,13 +9,13 @@ Copyright (c) 2024, 2025, Oracle and/or its affiliates.
 Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 -->
 
-The {{ .Site.Params.LongName | markdownify }} is not configured out-of-the-box. To enable functionality, an embedding model, language model, database, and optionally, Oracle Cloud Infrastructure (OCI) will need to be configured.
+The **{{< param "LongName" >}}** is not configured out-of-the-box. To enable functionality, an embedding model, language model, database, and optionally, Oracle Cloud Infrastructure (OCI) will need to be configured.
 
-Once you have configured the {{ .Site.Params.ShortName | markdownify }}, the settings can be exported to be imported into another deployment or after a restart.
+Once you have configured the **{{< param "ShortName" >}}**, the settings can be exported to be imported into another deployment or after a restart.
 
 ## 🤖 Model Configuration
 
-At a minimum, a large language model (LLM) will need to be configured to experiment with the {{ .Site.Params.LongName | markdownify }}. The LLM can be a third-party LLM, such as ChatGPT or Perplexity, or an on-premises LLM.
+At a minimum, a large language model (LLM) will need to be configured to experiment with the **{{< param "LongName" >}}**. The LLM can be a third-party LLM, such as ChatGPT or Perplexity, or an on-premises LLM.
 
 Additionally, to enable Retrieval-Augmented Generation (RAG) capabilities, an embedding model will need to be configured and enabled.
 
@@ -39,6 +39,6 @@ For more information on configuring OCI, please read about [OCI Configuration](o
 
 ## 💾 Settings
 
-Once you have configured the {{ .Site.Params.LongName | markdownify }}, you can export the settings and import them after a restart or new deployment.
+Once you have configured the **{{< param "LongName" >}}**, you can export the settings and import them after a restart or new deployment.
 
 For more information on importing (and exporting) settings, please read about [Settings](settings/).

--- a/docs/content/sandbox/configuration/db_config.md
+++ b/docs/content/sandbox/configuration/db_config.md
@@ -10,15 +10,15 @@ Licensed under the Universal Permissive License v1.0 as shown at http://oss.orac
 spell-checker: ignore tablespace mycomplexsecret mycomplexwalletsecret sandboxdb oaim
 -->
 
-To use the Retrieval-Augmented Generation (RAG) functionality of the **Sandbox**, you will need to setup/enable an [embedding model](../model_config) and have access to an **Oracle Database 23ai**. Both the [Always Free Oracle Autonomous Database Serverless (ADB-S)](https://docs.oracle.com/en/cloud/paas/autonomous-database/serverless/adbsb/autonomous-always-free.html) and the [Oracle Database 23ai Free](https://www.oracle.com/uk/database/free/get-started/) are supported. They are a great, no-cost, way to get up and running quickly.
+To use the Retrieval-Augmented Generation (RAG) functionality of the {{ .Site.Params.ShortName | markdownify }}, you will need to setup/enable an [embedding model](../model_config) and have access to an **Oracle Database 23ai**. Both the [Always Free Oracle Autonomous Database Serverless (ADB-S)](https://docs.oracle.com/en/cloud/paas/autonomous-database/serverless/adbsb/autonomous-always-free.html) and the [Oracle Database 23ai Free](https://www.oracle.com/uk/database/free/get-started/) are supported. They are a great, no-cost, way to get up and running quickly.
 
 ## Configuration
 
-The database can either be configured through the [**Sandbox** interface](#sandbox-interface) or by using [environment variables](#environment-variables).
+The database can either be configured through the [{{ .Site.Params.ShortName | markdownify }} interface](#sandbox-interface) or by using [environment variables](#environment-variables).
 
-### Sandbox Interface
+### {{ .Site.Params.ShortName | markdownify }} Interface
 
-To configure the Database from the Sandbox, navigate to `Configuration -> Database`:
+To configure the Database from the {{ .Site.Params.ShortName | markdownify }}, navigate to `Configuration -> Database`:
 
 ![Database Config](../images/database_config.png)
 
@@ -41,7 +41,7 @@ Once all fields are set, click the `Save` button.
 
 ### Environment Variables
 
-The following environment variables can be set, prior to starting the Sandbox, to automatically configure the database:
+The following environment variables can be set, prior to starting the {{ .Site.Params.ShortName | markdownify }}, to automatically configure the database:
 
 - **DB_USERNAME**: The pre-created [database username](#database-user) where the embeddings will be stored
 - **DB_PASSWORD**: The password for the `DB Username`
@@ -68,7 +68,7 @@ If using and ADB-S wallet, unzip the contents into the `TNS_ADMIN` directory. Th
 
 ### Bare-Metal Installation
 
-For bare-metal installations, set the `TNS_ADMIN` environment variable, or copy the contents of your current TNS_ADMIN to `src/tns_admin` before starting the **Sandbox**.
+For bare-metal installations, set the `TNS_ADMIN` environment variable, or copy the contents of your current TNS_ADMIN to `src/tns_admin` before starting the {{ .Site.Params.ShortName | markdownify }}.
 
 ### Container Installation
 

--- a/docs/content/sandbox/configuration/db_config.md
+++ b/docs/content/sandbox/configuration/db_config.md
@@ -10,15 +10,15 @@ Licensed under the Universal Permissive License v1.0 as shown at http://oss.orac
 spell-checker: ignore tablespace mycomplexsecret mycomplexwalletsecret sandboxdb oaim
 -->
 
-To use the Retrieval-Augmented Generation (RAG) functionality of the {{ .Site.Params.ShortName | markdownify }}, you will need to setup/enable an [embedding model](../model_config) and have access to an **Oracle Database 23ai**. Both the [Always Free Oracle Autonomous Database Serverless (ADB-S)](https://docs.oracle.com/en/cloud/paas/autonomous-database/serverless/adbsb/autonomous-always-free.html) and the [Oracle Database 23ai Free](https://www.oracle.com/uk/database/free/get-started/) are supported. They are a great, no-cost, way to get up and running quickly.
+To use the Retrieval-Augmented Generation (RAG) functionality of the **{{< param "ShortName" >}}**, you will need to setup/enable an [embedding model](../model_config) and have access to an **Oracle Database 23ai**. Both the [Always Free Oracle Autonomous Database Serverless (ADB-S)](https://docs.oracle.com/en/cloud/paas/autonomous-database/serverless/adbsb/autonomous-always-free.html) and the [Oracle Database 23ai Free](https://www.oracle.com/uk/database/free/get-started/) are supported. They are a great, no-cost, way to get up and running quickly.
 
 ## Configuration
 
-The database can either be configured through the [{{ .Site.Params.ShortName | markdownify }} interface](#sandbox-interface) or by using [environment variables](#environment-variables).
+The database can either be configured through the [**{{< param "ShortName" >}}** interface](#sandbox-interface) or by using [environment variables](#environment-variables).
 
-### {{ .Site.Params.ShortName | markdownify }} Interface
+### **{{< param "ShortName" >}}** Interface
 
-To configure the Database from the {{ .Site.Params.ShortName | markdownify }}, navigate to `Configuration -> Database`:
+To configure the Database from the **{{< param "ShortName" >}}**, navigate to `Configuration -> Database`:
 
 ![Database Config](../images/database_config.png)
 
@@ -41,7 +41,7 @@ Once all fields are set, click the `Save` button.
 
 ### Environment Variables
 
-The following environment variables can be set, prior to starting the {{ .Site.Params.ShortName | markdownify }}, to automatically configure the database:
+The following environment variables can be set, prior to starting the **{{< param "ShortName" >}}**, to automatically configure the database:
 
 - **DB_USERNAME**: The pre-created [database username](#database-user) where the embeddings will be stored
 - **DB_PASSWORD**: The password for the `DB Username`
@@ -68,7 +68,7 @@ If using and ADB-S wallet, unzip the contents into the `TNS_ADMIN` directory. Th
 
 ### Bare-Metal Installation
 
-For bare-metal installations, set the `TNS_ADMIN` environment variable, or copy the contents of your current TNS_ADMIN to `src/tns_admin` before starting the {{ .Site.Params.ShortName | markdownify }}.
+For bare-metal installations, set the `TNS_ADMIN` environment variable, or copy the contents of your current TNS_ADMIN to `src/tns_admin` before starting the **{{< param "ShortName" >}}**.
 
 ### Container Installation
 

--- a/docs/content/sandbox/configuration/model_config.md
+++ b/docs/content/sandbox/configuration/model_config.md
@@ -11,10 +11,10 @@ spell-checker:ignore ollama, mxbai, nomic, thenlper, minilm, uniqueid, huggingfa
 
 ## Supported Models
 
-At a minimum, a Large _Language Model_ (LLM) must be configured in {{ .Site.Params.LongName | markdownify }} for basic functionality. For Retrieval-Augmented Generation (**RAG**), an _Embedding Model_ will also need to be configured.
+At a minimum, a Large _Language Model_ (LLM) must be configured in **{{< param "LongName" >}}** for basic functionality. For Retrieval-Augmented Generation (**RAG**), an _Embedding Model_ will also need to be configured.
 
 {{% notice style="default" title="Model APIs" icon="circle-info" %}}
-If there is a specific model API that you would like to use with the {{ .Site.Params.LongName | markdownify }}, please [open an issue in GitHub](https://github.com/oracle-samples/oaim-sandbox/issues/new).  
+If there is a specific model API that you would like to use with the **{{< param "LongName" >}}**, please [open an issue in GitHub](https://github.com/oracle-samples/oaim-sandbox/issues/new).  
 {{% /notice %}}
 
 | Type  | API                                                      | Location      |
@@ -34,9 +34,9 @@ If there is a specific model API that you would like to use with the {{ .Site.Pa
 
 ## Configuration
 
-The models can either be configured using environment variables or through the {{ .Site.Params.ShortName | markdownify }} interface. To configure models through environment variables, please read the [Additional Information](#additional-information) about the specific model you would like to configure.
+The models can either be configured using environment variables or through the **{{< param "ShortName" >}}** interface. To configure models through environment variables, please read the [Additional Information](#additional-information) about the specific model you would like to configure.
 
-To configure an LLM or embedding model from the {{ .Site.Params.ShortName | markdownify }}, navigate to `Configuration -> Models`:
+To configure an LLM or embedding model from the **{{< param "ShortName" >}}**, navigate to `Configuration -> Models`:
 
 ![Model Config](../images/models_config.png)
 
@@ -50,7 +50,7 @@ Set the API, API Keys, API URL and other parameters as required.  Parameters suc
 
 #### API
 
-The {{ .Site.Params.ShortName | markdownify }} supports a number of model API's.  When adding a model, choose the most appropriate Model API.  If unsure, or the specific API is not listed, try *CompatOpenAI* or *CompatOpenAIEmbeddings* before [opening an issue](https://github.com/oracle-samples/oaim-sandbox/issues/new?template=additional_model_support) requesting an additional model API support.
+The **{{< param "ShortName" >}}** supports a number of model API's.  When adding a model, choose the most appropriate Model API.  If unsure, or the specific API is not listed, try *CompatOpenAI* or *CompatOpenAIEmbeddings* before [opening an issue](https://github.com/oracle-samples/oaim-sandbox/issues/new?template=additional_model_support) requesting an additional model API support.
 
 There are a number of local AI Model runners that use OpenAI compatible API's, including:
 - [LM Studio](https://lmstudio.ai)
@@ -84,7 +84,7 @@ On-Premises models, such as those from [Ollama](https://ollama.com/) or [Hugging
 
 Please follow the [Getting Started](https://docs.oracle.com/en-us/iaas/Content/generative-ai/getting-started.htm) guide for deploying the service in your OCI tenancy.
 
-To use OCI GenAI, the {{ .Site.Params.ShortName | markdownify }} must be configured for [OCI access](oci_config); including the Compartment OCID for the OCI GenAI service.
+To use OCI GenAI, the **{{< param "ShortName" >}}** must be configured for [OCI access](oci_config); including the Compartment OCID for the OCI GenAI service.
 
 >[!code]Skip the GUI!
 >You can set the following environment variables to automatically enable OCI GenAI models:
@@ -105,7 +105,7 @@ To use OCI GenAI, the {{ .Site.Params.ShortName | markdownify }} must be configu
 
 [Ollama](https://ollama.com/) is an open-source project that simplifies the running of LLMs and Embedding Models On-Premises.
 
-When configuring an Ollama model in the {{ .Site.Params.ShortName | markdownify }}, set the `API Server` URL (e.g `http://127.0.0.1:11434`) and leave the API Key blank. Substitute the IP Address with the IP of where Ollama is running.
+When configuring an Ollama model in the **{{< param "ShortName" >}}**, set the `API Server` URL (e.g `http://127.0.0.1:11434`) and leave the API Key blank. Substitute the IP Address with the IP of where Ollama is running.
 
 >[!code]Skip the GUI!
 >You can set the following environment variable to automatically set the `API Server` URL and enable Ollama models (change the IP address and Port, as applicable to your environment):
@@ -190,9 +190,9 @@ Example of running thenlper/gte-base in a container:
 {{% tab title="Cohere" %}}
 # Cohere
 
-[Cohere](https://cohere.com/) is an AI-powered answer engine. To use Cohere, you will need to sign-up and provide the {{ .Site.Params.ShortName | markdownify }} an API Key.  Cohere offers a free-trial, rate-limited API Key.
+[Cohere](https://cohere.com/) is an AI-powered answer engine. To use Cohere, you will need to sign-up and provide the **{{< param "ShortName" >}}** an API Key.  Cohere offers a free-trial, rate-limited API Key.
 
-**WARNING:** Cohere is a cloud model and you should familiarize yourself with their Privacy Policies if using it to experiment with private, sensitive data in the {{ .Site.Params.ShortName | markdownify }}.
+**WARNING:** Cohere is a cloud model and you should familiarize yourself with their Privacy Policies if using it to experiment with private, sensitive data in the **{{< param "ShortName" >}}**.
 
 >[!code]Skip the GUI!
 >You can set the following environment variable to automatically set the `API Key` and enable Perplexity models:
@@ -204,9 +204,9 @@ Example of running thenlper/gte-base in a container:
 {{% tab title="OpenAI" %}}
 # OpenAI
 
-[OpenAI](https://openai.com/api/) is an AI research organization behind the popular, online ChatGPT chatbot. To use OpenAI models, you will need to sign-up, purchase credits, and provide the {{ .Site.Params.ShortName | markdownify }} an API Key.
+[OpenAI](https://openai.com/api/) is an AI research organization behind the popular, online ChatGPT chatbot. To use OpenAI models, you will need to sign-up, purchase credits, and provide the **{{< param "ShortName" >}}** an API Key.
 
-**WARNING:** OpenAI is a cloud model and you should familiarize yourself with their Privacy Policies if using it to experiment with private, sensitive data in the {{ .Site.Params.ShortName | markdownify }}.
+**WARNING:** OpenAI is a cloud model and you should familiarize yourself with their Privacy Policies if using it to experiment with private, sensitive data in the **{{< param "ShortName" >}}**.
 
 >[!code]Skip the GUI!
 >You can set the following environment variable to automatically set the `API Key` and enable OpenAI models:
@@ -225,9 +225,9 @@ Many "AI Runners" provide OpenAI compatible APIs.  These can be used without any
 {{% tab title="Perplexity AI" %}}
 # Perplexity AI
 
-[Perplexity AI](https://docs.perplexity.ai/getting-started) is an AI-powered answer engine. To use Perplexity AI models, you will need to sign-up, purchase credits, and provide the {{ .Site.Params.ShortName | markdownify }} an API Key.
+[Perplexity AI](https://docs.perplexity.ai/getting-started) is an AI-powered answer engine. To use Perplexity AI models, you will need to sign-up, purchase credits, and provide the **{{< param "ShortName" >}}** an API Key.
 
-**WARNING:** Perplexity AI is a cloud model and you should familiarize yourself with their Privacy Policies if using it to experiment with private, sensitive data in the {{ .Site.Params.ShortName | markdownify }}.
+**WARNING:** Perplexity AI is a cloud model and you should familiarize yourself with their Privacy Policies if using it to experiment with private, sensitive data in the **{{< param "ShortName" >}}**.
 
 >[!code]Skip the GUI!
 >You can set the following environment variable to automatically set the `API Key` and enable Perplexity models:

--- a/docs/content/sandbox/configuration/model_config.md
+++ b/docs/content/sandbox/configuration/model_config.md
@@ -11,10 +11,10 @@ spell-checker:ignore ollama, mxbai, nomic, thenlper, minilm, uniqueid, huggingfa
 
 ## Supported Models
 
-At a minimum, a Large _Language Model_ (LLM) must be configured in **Oracle AI Microservices Sandbox** for basic functionality. For Retrieval-Augmented Generation (**RAG**), an _Embedding Model_ will also need to be configured.
+At a minimum, a Large _Language Model_ (LLM) must be configured in {{ .Site.Params.LongName | markdownify }} for basic functionality. For Retrieval-Augmented Generation (**RAG**), an _Embedding Model_ will also need to be configured.
 
 {{% notice style="default" title="Model APIs" icon="circle-info" %}}
-If there is a specific model API that you would like to use with the **Oracle AI Microservices Sandbox**, please [open an issue in GitHub](https://github.com/oracle-samples/oaim-sandbox/issues/new).  
+If there is a specific model API that you would like to use with the {{ .Site.Params.LongName | markdownify }}, please [open an issue in GitHub](https://github.com/oracle-samples/oaim-sandbox/issues/new).  
 {{% /notice %}}
 
 | Type  | API                                                      | Location      |
@@ -34,9 +34,9 @@ If there is a specific model API that you would like to use with the **Oracle AI
 
 ## Configuration
 
-The models can either be configured using environment variables or through the **Sandbox** interface. To configure models through environment variables, please read the [Additional Information](#additional-information) about the specific model you would like to configure.
+The models can either be configured using environment variables or through the {{ .Site.Params.ShortName | markdownify }} interface. To configure models through environment variables, please read the [Additional Information](#additional-information) about the specific model you would like to configure.
 
-To configure an LLM or embedding model from the **Sandbox**, navigate to `Configuration -> Models`:
+To configure an LLM or embedding model from the {{ .Site.Params.ShortName | markdownify }}, navigate to `Configuration -> Models`:
 
 ![Model Config](../images/models_config.png)
 
@@ -50,7 +50,7 @@ Set the API, API Keys, API URL and other parameters as required.  Parameters suc
 
 #### API
 
-The **Sandbox** supports a number of model API's.  When adding a model, choose the most appropriate Model API.  If unsure, or the specific API is not listed, try *CompatOpenAI* or *CompatOpenAIEmbeddings* before [opening an issue](https://github.com/oracle-samples/oaim-sandbox/issues/new?template=additional_model_support) requesting an additional model API support.
+The {{ .Site.Params.ShortName | markdownify }} supports a number of model API's.  When adding a model, choose the most appropriate Model API.  If unsure, or the specific API is not listed, try *CompatOpenAI* or *CompatOpenAIEmbeddings* before [opening an issue](https://github.com/oracle-samples/oaim-sandbox/issues/new?template=additional_model_support) requesting an additional model API support.
 
 There are a number of local AI Model runners that use OpenAI compatible API's, including:
 - [LM Studio](https://lmstudio.ai)
@@ -84,7 +84,7 @@ On-Premises models, such as those from [Ollama](https://ollama.com/) or [Hugging
 
 Please follow the [Getting Started](https://docs.oracle.com/en-us/iaas/Content/generative-ai/getting-started.htm) guide for deploying the service in your OCI tenancy.
 
-To use OCI GenAI, the **Sandbox** must be configured for [OCI access](oci_config); including the Compartment OCID for the OCI GenAI service.
+To use OCI GenAI, the {{ .Site.Params.ShortName | markdownify }} must be configured for [OCI access](oci_config); including the Compartment OCID for the OCI GenAI service.
 
 >[!code]Skip the GUI!
 >You can set the following environment variables to automatically enable OCI GenAI models:
@@ -105,7 +105,7 @@ To use OCI GenAI, the **Sandbox** must be configured for [OCI access](oci_config
 
 [Ollama](https://ollama.com/) is an open-source project that simplifies the running of LLMs and Embedding Models On-Premises.
 
-When configuring an Ollama model in the **Sandbox**, set the `API Server` URL (e.g `http://127.0.0.1:11434`) and leave the API Key blank. Substitute the IP Address with the IP of where Ollama is running.
+When configuring an Ollama model in the {{ .Site.Params.ShortName | markdownify }}, set the `API Server` URL (e.g `http://127.0.0.1:11434`) and leave the API Key blank. Substitute the IP Address with the IP of where Ollama is running.
 
 >[!code]Skip the GUI!
 >You can set the following environment variable to automatically set the `API Server` URL and enable Ollama models (change the IP address and Port, as applicable to your environment):
@@ -190,9 +190,9 @@ Example of running thenlper/gte-base in a container:
 {{% tab title="Cohere" %}}
 # Cohere
 
-[Cohere](https://cohere.com/) is an AI-powered answer engine. To use Cohere, you will need to sign-up and provide the **Sandbox** an API Key.  Cohere offers a free-trial, rate-limited API Key.
+[Cohere](https://cohere.com/) is an AI-powered answer engine. To use Cohere, you will need to sign-up and provide the {{ .Site.Params.ShortName | markdownify }} an API Key.  Cohere offers a free-trial, rate-limited API Key.
 
-**WARNING:** Cohere is a cloud model and you should familiarize yourself with their Privacy Policies if using it to experiment with private, sensitive data in the **Sandbox**.
+**WARNING:** Cohere is a cloud model and you should familiarize yourself with their Privacy Policies if using it to experiment with private, sensitive data in the {{ .Site.Params.ShortName | markdownify }}.
 
 >[!code]Skip the GUI!
 >You can set the following environment variable to automatically set the `API Key` and enable Perplexity models:
@@ -204,9 +204,9 @@ Example of running thenlper/gte-base in a container:
 {{% tab title="OpenAI" %}}
 # OpenAI
 
-[OpenAI](https://openai.com/api/) is an AI research organization behind the popular, online ChatGPT chatbot. To use OpenAI models, you will need to sign-up, purchase credits, and provide the **Sandbox** an API Key.
+[OpenAI](https://openai.com/api/) is an AI research organization behind the popular, online ChatGPT chatbot. To use OpenAI models, you will need to sign-up, purchase credits, and provide the {{ .Site.Params.ShortName | markdownify }} an API Key.
 
-**WARNING:** OpenAI is a cloud model and you should familiarize yourself with their Privacy Policies if using it to experiment with private, sensitive data in the **Sandbox**.
+**WARNING:** OpenAI is a cloud model and you should familiarize yourself with their Privacy Policies if using it to experiment with private, sensitive data in the {{ .Site.Params.ShortName | markdownify }}.
 
 >[!code]Skip the GUI!
 >You can set the following environment variable to automatically set the `API Key` and enable OpenAI models:
@@ -225,9 +225,9 @@ Many "AI Runners" provide OpenAI compatible APIs.  These can be used without any
 {{% tab title="Perplexity AI" %}}
 # Perplexity AI
 
-[Perplexity AI](https://docs.perplexity.ai/getting-started) is an AI-powered answer engine. To use Perplexity AI models, you will need to sign-up, purchase credits, and provide the **Sandbox** an API Key.
+[Perplexity AI](https://docs.perplexity.ai/getting-started) is an AI-powered answer engine. To use Perplexity AI models, you will need to sign-up, purchase credits, and provide the {{ .Site.Params.ShortName | markdownify }} an API Key.
 
-**WARNING:** Perplexity AI is a cloud model and you should familiarize yourself with their Privacy Policies if using it to experiment with private, sensitive data in the **Sandbox**.
+**WARNING:** Perplexity AI is a cloud model and you should familiarize yourself with their Privacy Policies if using it to experiment with private, sensitive data in the {{ .Site.Params.ShortName | markdownify }}.
 
 >[!code]Skip the GUI!
 >You can set the following environment variable to automatically set the `API Key` and enable Perplexity models:

--- a/docs/content/sandbox/configuration/oci_config.md
+++ b/docs/content/sandbox/configuration/oci_config.md
@@ -10,19 +10,19 @@ Licensed under the Universal Permissive License v1.0 as shown at http://oss.orac
 spell-checker: ignore genai ocid
 -->
 
-Oracle Cloud Infrastructure (OCI) can _optionally_ be configured to enable additional **Sandbox** functionality including:
+Oracle Cloud Infrastructure (OCI) can _optionally_ be configured to enable additional {{ .Site.Params.ShortName | markdownify }} functionality including:
 
 - Document Source for Splitting and Embedding from [Object Storage](https://docs.oracle.com/en-us/iaas/Content/Object/Concepts/objectstorageoverview.htm)
 - Private Cloud Large Language and Embedding models from [OCI Generative AI service](https://docs.oracle.com/en-us/iaas/Content/generative-ai/home.htm)
 
 ## Configuration
 
-OCI can either be configured through the [**Sandbox** interface](#sandbox-interface), a [CLI Configuration File](#config-file), or by using [environment variables](#environment-variables).  
+OCI can either be configured through the [{{ .Site.Params.ShortName | markdownify }} interface](#{{ .Site.Params.ShortName | markdownify }}-interface), a [CLI Configuration File](#config-file), or by using [environment variables](#environment-variables).  
 You will need to [generate an API Key](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#two) to obtain the required configuration values.
 
-### Sandbox Interface
+### {{ .Site.Params.ShortName | markdownify }} Interface
 
-To configure the Database from the Sandbox, navigate to `Configuration -> OCI`:
+To configure the Database from the {{ .Site.Params.ShortName | markdownify }}, navigate to `Configuration -> OCI`:
 
 ![OCI Config](../images/oci_config.png)
 
@@ -34,7 +34,7 @@ Provide the values obtained by [generating an API Key](https://docs.oracle.com/e
 
 ### Config File
 
-During startup, the **Sandbox** will look for and consume a [CLI Configuration File](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm) for configuring OCI access.
+During startup, the {{ .Site.Params.ShortName | markdownify }} will look for and consume a [CLI Configuration File](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm) for configuring OCI access.
 
 In addition to the standard entries, two additional entries are required to enable OCI GenAI Services:
 
@@ -44,7 +44,7 @@ In addition to the standard entries, two additional entries are required to enab
 
 ### Environment Variables
 
-During start, the **Sandbox** will use environment variables to configure OCI.  Environment variables will take precedence over the CLI Configuration file.
+During start, the {{ .Site.Params.ShortName | markdownify }} will use environment variables to configure OCI.  Environment variables will take precedence over the CLI Configuration file.
 
 In addition to the [standard environment variables](https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/clienvironmentvariables.htm#CLI_Environment_Variables), the following variables can be set to enable OCI GenAI Services:
 

--- a/docs/content/sandbox/configuration/oci_config.md
+++ b/docs/content/sandbox/configuration/oci_config.md
@@ -10,19 +10,19 @@ Licensed under the Universal Permissive License v1.0 as shown at http://oss.orac
 spell-checker: ignore genai ocid
 -->
 
-Oracle Cloud Infrastructure (OCI) can _optionally_ be configured to enable additional {{ .Site.Params.ShortName | markdownify }} functionality including:
+Oracle Cloud Infrastructure (OCI) can _optionally_ be configured to enable additional **{{< param "ShortName" >}}** functionality including:
 
 - Document Source for Splitting and Embedding from [Object Storage](https://docs.oracle.com/en-us/iaas/Content/Object/Concepts/objectstorageoverview.htm)
 - Private Cloud Large Language and Embedding models from [OCI Generative AI service](https://docs.oracle.com/en-us/iaas/Content/generative-ai/home.htm)
 
 ## Configuration
 
-OCI can either be configured through the [{{ .Site.Params.ShortName | markdownify }} interface](#{{ .Site.Params.ShortName | markdownify }}-interface), a [CLI Configuration File](#config-file), or by using [environment variables](#environment-variables).  
+OCI can either be configured through the [**{{< param "ShortName" >}}** interface](#**{{< param "ShortName" >}}**-interface), a [CLI Configuration File](#config-file), or by using [environment variables](#environment-variables).  
 You will need to [generate an API Key](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#two) to obtain the required configuration values.
 
-### {{ .Site.Params.ShortName | markdownify }} Interface
+### **{{< param "ShortName" >}}** Interface
 
-To configure the Database from the {{ .Site.Params.ShortName | markdownify }}, navigate to `Configuration -> OCI`:
+To configure the Database from the **{{< param "ShortName" >}}**, navigate to `Configuration -> OCI`:
 
 ![OCI Config](../images/oci_config.png)
 
@@ -34,7 +34,7 @@ Provide the values obtained by [generating an API Key](https://docs.oracle.com/e
 
 ### Config File
 
-During startup, the {{ .Site.Params.ShortName | markdownify }} will look for and consume a [CLI Configuration File](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm) for configuring OCI access.
+During startup, the **{{< param "ShortName" >}}** will look for and consume a [CLI Configuration File](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm) for configuring OCI access.
 
 In addition to the standard entries, two additional entries are required to enable OCI GenAI Services:
 
@@ -44,7 +44,7 @@ In addition to the standard entries, two additional entries are required to enab
 
 ### Environment Variables
 
-During start, the {{ .Site.Params.ShortName | markdownify }} will use environment variables to configure OCI.  Environment variables will take precedence over the CLI Configuration file.
+During start, the **{{< param "ShortName" >}}** will use environment variables to configure OCI.  Environment variables will take precedence over the CLI Configuration file.
 
 In addition to the [standard environment variables](https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/clienvironmentvariables.htm#CLI_Environment_Variables), the following variables can be set to enable OCI GenAI Services:
 

--- a/docs/content/sandbox/configuration/settings.md
+++ b/docs/content/sandbox/configuration/settings.md
@@ -8,15 +8,15 @@ Copyright (c) 2024, 2025, Oracle and/or its affiliates.
 Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 -->
 
-Once you are happy with the specific configuration of your {{ .Site.Params.ShortName | markdownify }}, the settings can be exported in **.json** format.  Those settings can then be loaded in later to return the {{ .Site.Params.ShortName | markdownify }} to your previous configuration.  The settings an also be imported into another instance of the {{ .Site.Params.ShortName | markdownify }}.
+Once you are happy with the specific configuration of your **{{< param "ShortName" >}}**, the settings can be exported in **.json** format.  Those settings can then be loaded in later to return the **{{< param "ShortName" >}}** to your previous configuration.  The settings an also be imported into another instance of the **{{< param "ShortName" >}}**.
 
 ## View and Download
 
-To view and download the {{ .Site.Params.ShortName | markdownify }} configuration, navigate to `Configuration -> Settings`:
+To view and download the **{{< param "ShortName" >}}** configuration, navigate to `Configuration -> Settings`:
 
 ![Download Settings](../images/settings_download.png)
 
-{{< icon "triangle-exclamation" >}} Settings contain sensitive information such as database passwords and API Keys.  By default, these settings will not be exported and will have to be re-entered after uploading the settings in a new instance of the {{ .Site.Params.ShortName | markdownify }}.  If have a secure way to store the settings and would would like to export the sensitive data, tick the "Include Sensitive Settings" box.
+{{< icon "triangle-exclamation" >}} Settings contain sensitive information such as database passwords and API Keys.  By default, these settings will not be exported and will have to be re-entered after uploading the settings in a new instance of the **{{< param "ShortName" >}}**.  If have a secure way to store the settings and would would like to export the sensitive data, tick the "Include Sensitive Settings" box.
 
 ## Upload
 
@@ -40,4 +40,4 @@ If your configuration has both OLLAMA or OpenAI as providers for chat and embedd
 Currently mixed configurations, like Ollama for embeddings and OpenAI for chat completion are not allowed.
 {{% /notice %}}
 
-For more information, about the {{ .Site.Params.ShortName | markdownify }} and **SpringAI**, please view the [Advanced - SpringAI](/oaim-sandbox/advanced/springai) documentation.
+For more information, about the **{{< param "ShortName" >}}** and **SpringAI**, please view the [Advanced - SpringAI](/oaim-sandbox/advanced/springai) documentation.

--- a/docs/content/sandbox/configuration/settings.md
+++ b/docs/content/sandbox/configuration/settings.md
@@ -8,15 +8,15 @@ Copyright (c) 2024, 2025, Oracle and/or its affiliates.
 Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 -->
 
-Once you are happy with the specific configuration of your **Sandbox**, the settings can be exported in **.json** format.  Those settings can then be loaded in later to return the **Sandbox** to your previous configuration.  The settings an also be imported into another instance of the **Sandbox**.
+Once you are happy with the specific configuration of your {{ .Site.Params.ShortName | markdownify }}, the settings can be exported in **.json** format.  Those settings can then be loaded in later to return the {{ .Site.Params.ShortName | markdownify }} to your previous configuration.  The settings an also be imported into another instance of the {{ .Site.Params.ShortName | markdownify }}.
 
 ## View and Download
 
-To view and download the **Sandbox** configuration, navigate to `Configuration -> Settings`:
+To view and download the {{ .Site.Params.ShortName | markdownify }} configuration, navigate to `Configuration -> Settings`:
 
 ![Download Settings](../images/settings_download.png)
 
-{{< icon "triangle-exclamation" >}} Settings contain sensitive information such as database passwords and API Keys.  By default, these settings will not be exported and will have to be re-entered after uploading the settings in a new instance of the **Sandbox**.  If have a secure way to store the settings and would would like to export the sensitive data, tick the "Include Sensitive Settings" box.
+{{< icon "triangle-exclamation" >}} Settings contain sensitive information such as database passwords and API Keys.  By default, these settings will not be exported and will have to be re-entered after uploading the settings in a new instance of the {{ .Site.Params.ShortName | markdownify }}.  If have a secure way to store the settings and would would like to export the sensitive data, tick the "Include Sensitive Settings" box.
 
 ## Upload
 
@@ -40,4 +40,4 @@ If your configuration has both OLLAMA or OpenAI as providers for chat and embedd
 Currently mixed configurations, like Ollama for embeddings and OpenAI for chat completion are not allowed.
 {{% /notice %}}
 
-For more information, about the **Sandbox** and **SpringAI**, please view the [Advanced - SpringAI](/oaim-sandbox/advanced/springai) documentation.
+For more information, about the {{ .Site.Params.ShortName | markdownify }} and **SpringAI**, please view the [Advanced - SpringAI](/oaim-sandbox/advanced/springai) documentation.

--- a/docs/content/sandbox/tools/prompt_eng.md
+++ b/docs/content/sandbox/tools/prompt_eng.md
@@ -8,7 +8,7 @@ Copyright (c) 2024, 2025, Oracle and/or its affiliates.
 Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 -->
 
-Prompts are a set of instructions given to the language model to guide the response.  They are used to set the context or define the kind of response you are expecting.  The Oracle AI Microservices Sandbox (the **Sandbox**) provides both [System](#system-prompt) and [Context](#context-prompt) example prompts and allows you to modify these prompts to your needs.
+Prompts are a set of instructions given to the language model to guide the response.  They are used to set the context or define the kind of response you are expecting.  The **{{< param "LongName" >}}** (the **{{< param "ShortName" >}}**) provides both [System](#system-prompt) and [Context](#context-prompt) example prompts and allows you to modify these prompts to your needs.
 
 {{% icon star %}} The provided example prompts work for *most* models but they may not work the same way across all models.  Different models may interpret or respond to the instructions in various ways requiring you to modify the example prompts per-model.
 

--- a/docs/content/walkthrough/_index.md
+++ b/docs/content/walkthrough/_index.md
@@ -11,7 +11,7 @@ Licensed under the Universal Permissive License v1.0 as shown at http://oss.orac
 spell-checker: ignore mxbai, ollama, oaim, sqlplus, sysdba, spfile, freepdb, tablespace, firewalld, hnsw
 -->
 
-This walkthrough will guide you through a basic installation of the **Oracle AI Microservices Sandbox** (the **Sandbox**). It will allow you to experiment with GenAI, using Retrieval-Augmented Generation (**RAG**) with Oracle Database 23ai at the core.
+This walkthrough will guide you through a basic installation of the {{ .Site.Params.LongName | markdownify }}(the {{ .Site.Params.ShortName | markdownify }}). It will allow you to experiment with GenAI, using Retrieval-Augmented Generation (**RAG**) with Oracle Database 23ai at the core.
 
 By the end of the walkthrough you will be familiar with:
 
@@ -19,7 +19,7 @@ By the end of the walkthrough you will be familiar with:
 - Configuring an Embedding Model
 - Configuring the Vector Storage
 - Splitting, Embedding, and Storing vectors for **RAG**
-- Experimenting with the **Sandbox**
+- Experimenting with the {{ .Site.Params.ShortName | markdownify }}
 
 What you'll need for the walkthrough:
 
@@ -30,7 +30,7 @@ What you'll need for the walkthrough:
 - Sufficient GPU/CPU resources to run the **LLM**, embedding model, and database (see below).
 
 {{% notice style="code" title="Performance: A Word of Caution" icon="fire" %}}
-The performance of the **Sandbox** will vary depending on the infrastructure.
+The performance of the {{ .Site.Params.ShortName | markdownify }} will vary depending on the infrastructure.
 
 **LLM**s and Embedding Models are designed to use GPUs, but this walkthrough _can work_ on machines with just CPUs; albeit _much_ slower!
 When testing the **LLM**, if you don't get a response in a couple of minutes; your hardware is not sufficient to continue with the walkthrough.
@@ -50,7 +50,7 @@ You will run four container images to establish the "Infrastructure":
 - On-Premises **LLM** - llama3.1
 - On-Premises Embedding Model - mxbai-embed-large
 - Vector Storage - Oracle Database 23ai Free
-- The **Sandbox**
+- The {{ .Site.Params.ShortName | markdownify }}
 
 ### LLM - llama3.1
 
@@ -126,7 +126,7 @@ To enable the **RAG** functionality, access to an embedding model is required. T
 
 ### Vector Storage - Oracle Database 23ai Free
 
-AI Vector Search in Oracle Database 23ai provides the ability to store and query private business data using a natural language interface. The **Sandbox** uses these capabilities to provide more accurate and relevant **LLM** responses via Retrieval-Augmented Generation (**RAG**). [Oracle Database 23ai Free](https://www.oracle.com/uk/database/free/get-started/) provides an ideal, no-cost vector store for this walkthrough.
+AI Vector Search in Oracle Database 23ai provides the ability to store and query private business data using a natural language interface. The {{ .Site.Params.ShortName | markdownify }} uses these capabilities to provide more accurate and relevant **LLM** responses via Retrieval-Augmented Generation (**RAG**). [Oracle Database 23ai Free](https://www.oracle.com/uk/database/free/get-started/) provides an ideal, no-cost vector store for this walkthrough.
 
 To start Oracle Database 23ai Free:
 
@@ -162,11 +162,11 @@ To start Oracle Database 23ai Free:
    podman container restart oaim-db
    ```
 
-### Oracle AI Microservices Sandbox
+### {{ .Site.Params.LongName | markdownify }}
 
-The **Sandbox** provides an easy to use front-end for experimenting with **LLM** parameters and **RAG**.
+The {{ .Site.Params.ShortName | markdownify }} provides an easy to use front-end for experimenting with **LLM** parameters and **RAG**.
 
-1. Download and Unzip the latest version of the **Sandbox**:
+1. Download and Unzip the latest version of the {{ .Site.Params.ShortName | markdownify }}:
 
    ```bash
    curl -L -o oaim-sandbox.tar.gz https://github.com/oracle-samples/oaim-sandbox/archive/refs/heads/main.tar.gz
@@ -181,7 +181,7 @@ The **Sandbox** provides an easy to use front-end for experimenting with **LLM**
    podman build --arch amd64 -t localhost/oaim-sandbox-aio:latest .
    ```
 
-1. Start the **Sandbox**:
+1. Start the {{ .Site.Params.ShortName | markdownify }}:
 
    ```bash
    podman run -d --name oaim-sandbox-aio --network=host localhost/oaim-sandbox-aio:latest
@@ -190,7 +190,7 @@ The **Sandbox** provides an easy to use front-end for experimenting with **LLM**
    Operating System specific instructions:
    {{< tabs "sandbox" >}}
    {{% tab title="Linux" %}}
-   If you are running the **Sandbox** on a remote host, you may need to allow access to the `8501` port.
+   If you are running the {{ .Site.Params.ShortName | markdownify }} on a remote host, you may need to allow access to the `8501` port.
 
    For example, in Oracle Linux 8/9 with `firewalld`:
 
@@ -209,7 +209,7 @@ The **Sandbox** provides an easy to use front-end for experimenting with **LLM**
 
 ## Configuration
 
-With the "Infrastructure" in-place, you're ready to configure the **Sandbox**. 
+With the "Infrastructure" in-place, you're ready to configure the {{ .Site.Params.ShortName | markdownify }}. 
 
 In a web browser, navigate to `http://localhost:8501`:
 ![Sandbox](images/chatbot_no_models.png)
@@ -224,7 +224,7 @@ To configure the On-Premises **LLM**, navigate to the _Configuration -> Models_ 
 ![Configure LLM](images/models_edit.png)
 1. Tick the _Enabled_ checkbox, leave all other settings as-is, and _Save_
 ![Enable LLM](images/models_enable_llm.png)
-{{% icon star %}} More information about configuring **LLM**s in the **Sandbox** can be found in the [Model Configuration](../sandbox/configuration/model_config) documentation.
+{{% icon star %}} More information about configuring **LLM**s in the {{ .Site.Params.ShortName | markdownify }} can be found in the [Model Configuration](../sandbox/configuration/model_config) documentation.
 
 #### Say "Hello?"
 
@@ -247,7 +247,7 @@ To configure the On-Premises Embedding Model, navigate back to the _Configuratio
 1. Enable the `mxbai-embed-large` Embedding Model following the same process as you did for the Language Model.
 ![Configure Embedding Model](images/models_enable_embed.png)
 
-{{% icon star %}}  More information about configuring embedding models in the **Sandbox** can be found in the [Model Configuration](../sandbox/configuration/model_config) documentation.
+{{% icon star %}}  More information about configuring embedding models in the {{ .Site.Params.ShortName | markdownify }} can be found in the [Model Configuration](../sandbox/configuration/model_config) documentation.
 
 ### Configure the Database
 
@@ -260,7 +260,7 @@ To configure Oracle Database 23ai Free, navigate to the _Configuration -> Databa
 
 ![Configure Database](../sandbox/configuration/images/database_config.png)
 
-{{% icon star %}} More information about configuring the database in the **Sandbox** can be found in the [Database Configuration](../sandbox/configuration/db_config) documentation.
+{{% icon star %}} More information about configuring the database in the {{ .Site.Params.ShortName | markdownify }} can be found in the [Database Configuration](../sandbox/configuration/db_config) documentation.
 
 ## Split and Embed
 
@@ -285,9 +285,9 @@ Depending on the infrastructure, the embedding process can take a few minutes. A
 ![Split and Embed](images/split_embed_web.png)
 
 {{% notice style="code" title="Thumb Twiddling" icon="circle-info" %}}
-You can watch the progress of the embedding by streaming the **Sandbox** logs: `podman logs -f oaim-sandbox-aio`
+You can watch the progress of the embedding by streaming the {{ .Site.Params.ShortName | markdownify }} logs: `podman logs -f oaim-sandbox-aio`
 
-Chunks are processed in batches. Wait until the **Sandbox** logs output: `POST Response: <Response [200]>` before continuing.
+Chunks are processed in batches. Wait until the {{ .Site.Params.ShortName | markdownify }} logs output: `POST Response: <Response [200]>` before continuing.
 {{% /notice %}}
 
 ### Query the Vector Store
@@ -310,7 +310,7 @@ From the command line:
 
 ## Experiment
 
-With the **Oracle AI Microservices Sandbox** configured, you're ready for some experimentation.
+With the {{ .Site.Params.LongName | markdownify }}configured, you're ready for some experimentation.
 
 Navigate back to the _ChatBot_. There will be no more configuration warnings.
 
@@ -342,12 +342,12 @@ Depending on your hardware, this may cause the response to be **_significantly_*
 
 ![Enable RAG](images/chatbot_rag_enable.png)
 
-By asking `Are you sure?`, you are taking advantage of the **Sandbox**'s history and context functionality.  
+By asking `Are you sure?`, you are taking advantage of the {{ .Site.Params.ShortName | markdownify }}'s history and context functionality.  
 The response should be different and include references to `DBMS_VECTOR` and links to the embedded documentation where this information can be found. It might even include an apology!
 
 ## What's Next?
 
-You should now have a solid foundation in utilizing the **Oracle AI Microservices Sandbox**.
+You should now have a solid foundation in utilizing the {{ .Site.Params.LongName | markdownify }}.
 To take your experiments to the next level, consider exploring these additional bits of functionality:
 
 - Turn On/Off/Clear history

--- a/docs/content/walkthrough/_index.md
+++ b/docs/content/walkthrough/_index.md
@@ -11,7 +11,7 @@ Licensed under the Universal Permissive License v1.0 as shown at http://oss.orac
 spell-checker: ignore mxbai, ollama, oaim, sqlplus, sysdba, spfile, freepdb, tablespace, firewalld, hnsw
 -->
 
-This walkthrough will guide you through a basic installation of the {{ .Site.Params.LongName | markdownify }}(the {{ .Site.Params.ShortName | markdownify }}). It will allow you to experiment with GenAI, using Retrieval-Augmented Generation (**RAG**) with Oracle Database 23ai at the core.
+This walkthrough will guide you through a basic installation of the **{{< param "LongName" >}}** (the **{{< param "ShortName" >}}**). It will allow you to experiment with GenAI, using Retrieval-Augmented Generation (**RAG**) with Oracle Database 23ai at the core.
 
 By the end of the walkthrough you will be familiar with:
 
@@ -19,7 +19,7 @@ By the end of the walkthrough you will be familiar with:
 - Configuring an Embedding Model
 - Configuring the Vector Storage
 - Splitting, Embedding, and Storing vectors for **RAG**
-- Experimenting with the {{ .Site.Params.ShortName | markdownify }}
+- Experimenting with the **{{< param "ShortName" >}}**
 
 What you'll need for the walkthrough:
 
@@ -30,7 +30,7 @@ What you'll need for the walkthrough:
 - Sufficient GPU/CPU resources to run the **LLM**, embedding model, and database (see below).
 
 {{% notice style="code" title="Performance: A Word of Caution" icon="fire" %}}
-The performance of the {{ .Site.Params.ShortName | markdownify }} will vary depending on the infrastructure.
+The performance of the **{{< param "ShortName" >}}** will vary depending on the infrastructure.
 
 **LLM**s and Embedding Models are designed to use GPUs, but this walkthrough _can work_ on machines with just CPUs; albeit _much_ slower!
 When testing the **LLM**, if you don't get a response in a couple of minutes; your hardware is not sufficient to continue with the walkthrough.
@@ -50,7 +50,7 @@ You will run four container images to establish the "Infrastructure":
 - On-Premises **LLM** - llama3.1
 - On-Premises Embedding Model - mxbai-embed-large
 - Vector Storage - Oracle Database 23ai Free
-- The {{ .Site.Params.ShortName | markdownify }}
+- The **{{< param "ShortName" >}}**
 
 ### LLM - llama3.1
 
@@ -126,7 +126,7 @@ To enable the **RAG** functionality, access to an embedding model is required. T
 
 ### Vector Storage - Oracle Database 23ai Free
 
-AI Vector Search in Oracle Database 23ai provides the ability to store and query private business data using a natural language interface. The {{ .Site.Params.ShortName | markdownify }} uses these capabilities to provide more accurate and relevant **LLM** responses via Retrieval-Augmented Generation (**RAG**). [Oracle Database 23ai Free](https://www.oracle.com/uk/database/free/get-started/) provides an ideal, no-cost vector store for this walkthrough.
+AI Vector Search in Oracle Database 23ai provides the ability to store and query private business data using a natural language interface. The **{{< param "ShortName" >}}** uses these capabilities to provide more accurate and relevant **LLM** responses via Retrieval-Augmented Generation (**RAG**). [Oracle Database 23ai Free](https://www.oracle.com/uk/database/free/get-started/) provides an ideal, no-cost vector store for this walkthrough.
 
 To start Oracle Database 23ai Free:
 
@@ -162,11 +162,11 @@ To start Oracle Database 23ai Free:
    podman container restart oaim-db
    ```
 
-### {{ .Site.Params.LongName | markdownify }}
+### **{{< param "LongName" >}}**
 
-The {{ .Site.Params.ShortName | markdownify }} provides an easy to use front-end for experimenting with **LLM** parameters and **RAG**.
+The **{{< param "ShortName" >}}** provides an easy to use front-end for experimenting with **LLM** parameters and **RAG**.
 
-1. Download and Unzip the latest version of the {{ .Site.Params.ShortName | markdownify }}:
+1. Download and Unzip the latest version of the **{{< param "ShortName" >}}**:
 
    ```bash
    curl -L -o oaim-sandbox.tar.gz https://github.com/oracle-samples/oaim-sandbox/archive/refs/heads/main.tar.gz
@@ -181,7 +181,7 @@ The {{ .Site.Params.ShortName | markdownify }} provides an easy to use front-end
    podman build --arch amd64 -t localhost/oaim-sandbox-aio:latest .
    ```
 
-1. Start the {{ .Site.Params.ShortName | markdownify }}:
+1. Start the **{{< param "ShortName" >}}**:
 
    ```bash
    podman run -d --name oaim-sandbox-aio --network=host localhost/oaim-sandbox-aio:latest
@@ -190,7 +190,7 @@ The {{ .Site.Params.ShortName | markdownify }} provides an easy to use front-end
    Operating System specific instructions:
    {{< tabs "sandbox" >}}
    {{% tab title="Linux" %}}
-   If you are running the {{ .Site.Params.ShortName | markdownify }} on a remote host, you may need to allow access to the `8501` port.
+   If you are running the **{{< param "ShortName" >}}** on a remote host, you may need to allow access to the `8501` port.
 
    For example, in Oracle Linux 8/9 with `firewalld`:
 
@@ -209,7 +209,7 @@ The {{ .Site.Params.ShortName | markdownify }} provides an easy to use front-end
 
 ## Configuration
 
-With the "Infrastructure" in-place, you're ready to configure the {{ .Site.Params.ShortName | markdownify }}. 
+With the "Infrastructure" in-place, you're ready to configure the **{{< param "ShortName" >}}**. 
 
 In a web browser, navigate to `http://localhost:8501`:
 ![Sandbox](images/chatbot_no_models.png)
@@ -224,7 +224,7 @@ To configure the On-Premises **LLM**, navigate to the _Configuration -> Models_ 
 ![Configure LLM](images/models_edit.png)
 1. Tick the _Enabled_ checkbox, leave all other settings as-is, and _Save_
 ![Enable LLM](images/models_enable_llm.png)
-{{% icon star %}} More information about configuring **LLM**s in the {{ .Site.Params.ShortName | markdownify }} can be found in the [Model Configuration](../sandbox/configuration/model_config) documentation.
+{{% icon star %}} More information about configuring **LLM**s in the **{{< param "ShortName" >}}** can be found in the [Model Configuration](../sandbox/configuration/model_config) documentation.
 
 #### Say "Hello?"
 
@@ -247,7 +247,7 @@ To configure the On-Premises Embedding Model, navigate back to the _Configuratio
 1. Enable the `mxbai-embed-large` Embedding Model following the same process as you did for the Language Model.
 ![Configure Embedding Model](images/models_enable_embed.png)
 
-{{% icon star %}}  More information about configuring embedding models in the {{ .Site.Params.ShortName | markdownify }} can be found in the [Model Configuration](../sandbox/configuration/model_config) documentation.
+{{% icon star %}}  More information about configuring embedding models in the **{{< param "ShortName" >}}** can be found in the [Model Configuration](../sandbox/configuration/model_config) documentation.
 
 ### Configure the Database
 
@@ -260,7 +260,7 @@ To configure Oracle Database 23ai Free, navigate to the _Configuration -> Databa
 
 ![Configure Database](../sandbox/configuration/images/database_config.png)
 
-{{% icon star %}} More information about configuring the database in the {{ .Site.Params.ShortName | markdownify }} can be found in the [Database Configuration](../sandbox/configuration/db_config) documentation.
+{{% icon star %}} More information about configuring the database in the **{{< param "ShortName" >}}** can be found in the [Database Configuration](../sandbox/configuration/db_config) documentation.
 
 ## Split and Embed
 
@@ -285,9 +285,9 @@ Depending on the infrastructure, the embedding process can take a few minutes. A
 ![Split and Embed](images/split_embed_web.png)
 
 {{% notice style="code" title="Thumb Twiddling" icon="circle-info" %}}
-You can watch the progress of the embedding by streaming the {{ .Site.Params.ShortName | markdownify }} logs: `podman logs -f oaim-sandbox-aio`
+You can watch the progress of the embedding by streaming the **{{< param "ShortName" >}}** logs: `podman logs -f oaim-sandbox-aio`
 
-Chunks are processed in batches. Wait until the {{ .Site.Params.ShortName | markdownify }} logs output: `POST Response: <Response [200]>` before continuing.
+Chunks are processed in batches. Wait until the **{{< param "ShortName" >}}** logs output: `POST Response: <Response [200]>` before continuing.
 {{% /notice %}}
 
 ### Query the Vector Store
@@ -310,7 +310,7 @@ From the command line:
 
 ## Experiment
 
-With the {{ .Site.Params.LongName | markdownify }}configured, you're ready for some experimentation.
+With the **{{< param "LongName" >}}**configured, you're ready for some experimentation.
 
 Navigate back to the _ChatBot_. There will be no more configuration warnings.
 
@@ -342,12 +342,12 @@ Depending on your hardware, this may cause the response to be **_significantly_*
 
 ![Enable RAG](images/chatbot_rag_enable.png)
 
-By asking `Are you sure?`, you are taking advantage of the {{ .Site.Params.ShortName | markdownify }}'s history and context functionality.  
+By asking `Are you sure?`, you are taking advantage of the **{{< param "ShortName" >}}**'s history and context functionality.  
 The response should be different and include references to `DBMS_VECTOR` and links to the embedded documentation where this information can be found. It might even include an apology!
 
 ## What's Next?
 
-You should now have a solid foundation in utilizing the {{ .Site.Params.LongName | markdownify }}.
+You should now have a solid foundation in utilizing the **{{< param "LongName" >}}**.
 To take your experiments to the next level, consider exploring these additional bits of functionality:
 
 - Turn On/Off/Clear history

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -28,8 +28,8 @@ enableRobotsTXT = true
   themeVariant = ['auto', 'sandbox-light', 'sandbox-dark']
   disableInlineCopyToClipBoard = true
   hideAuthorName = true
-  LongName = "**Oracle AI Explorer for Apps**"
-  ShortName = "**AI Explorer**"
+  LongName = "Oracle AI Explorer for Apps"
+  ShortName = "AI Explorer"
   
 [menu]
   [[menu.shortcuts]]

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -28,6 +28,8 @@ enableRobotsTXT = true
   themeVariant = ['auto', 'sandbox-light', 'sandbox-dark']
   disableInlineCopyToClipBoard = true
   hideAuthorName = true
+  LongName = "**Oracle AI Explorer for Apps**"
+  ShortName = "**AI Explorer**"
   
 [menu]
   [[menu.shortcuts]]


### PR DESCRIPTION
Modified all documentation for renaming from OAIM Sandbox to OAI Explorer for Apps.

I've edited the docs folder, so that the OAI Explorer is referenced as a parameter.