### PR TITLE
275 pull ollama models gui

### DIFF
--- a/src/client/app/content/config/tabs/models.py
+++ b/src/client/app/content/config/tabs/models.py
@@ -340,8 +340,6 @@ def pull_model_dialog(provider: str, model_id: str) -> None:
             if "error" in event:
                 st.error(f"Pull failed: {event['error']}")
                 return
-            if event.get("status") == "success":
-                break
             status = event.get("status", "")
             completed = event.get("completed", 0)
             total = event.get("total", 0)

--- a/src/client/app/content/config/tabs/models.py
+++ b/src/client/app/content/config/tabs/models.py
@@ -13,7 +13,7 @@ import streamlit as st
 from streamlit import session_state as state
 
 from client.app.core import helpers
-from client.app.core.api import api_delete, api_get, api_post, api_put
+from client.app.core.api import api_delete, api_get, api_post, api_post_stream, api_put
 
 LOGGER = logging.getLogger("client.content.config.tabs.models")
 
@@ -325,19 +325,53 @@ def edit_model(
 
 
 #####################################################
+# Pull Dialog
+#####################################################
+@st.dialog("Pull Ollama Model")
+def pull_model_dialog(provider: str, model_id: str) -> None:
+    """Stream Ollama model pull progress."""
+    st.write(f"Pulling **{provider}/{model_id}** from Ollama registry...")
+    quoted_id = urllib.parse.quote(model_id, safe="")
+    status_text = st.empty()
+    progress_bar = st.empty()
+
+    try:
+        for event in api_post_stream(f"models/pull/{provider}/{quoted_id}"):
+            if "error" in event:
+                st.error(f"Pull failed: {event['error']}")
+                return
+            if event.get("status") == "success":
+                break
+            status = event.get("status", "")
+            completed = event.get("completed", 0)
+            total = event.get("total", 0)
+            if total > 0:
+                progress_bar.progress(completed / total, text=status)
+            else:
+                status_text.text(status)
+    except httpx.HTTPStatusError as exc:
+        st.error(f"Pull failed: {helpers.extract_error_detail(exc)}")
+        return
+
+    helpers.refresh_settings()
+    st.success(f"Model **{model_id}** pulled successfully. You can now enable it.")
+
+
+#####################################################
 # Table Display
 #####################################################
 def render_model_rows(model_type: str) -> None:
     """Render rows of the models."""
     models = [m for m in state["settings"]["model_configs"] if m.get("type") == model_type]
-    data_col_widths = [0.06, 0.44, 0.38, 0.12]
+    data_col_widths = [0.06, 0.40, 0.34, 0.10, 0.10]
 
     table_col_format = st.columns(data_col_widths, vertical_alignment="center")
-    col1, col2, col3, col4 = table_col_format
+    col1, col2, col3, col4, col5 = table_col_format
     col1.markdown("&#x200B;", unsafe_allow_html=True, width="content")
     col2.markdown("**<u>Model</u>**", unsafe_allow_html=True)
     col3.markdown("**<u>Provider URL</u>**", unsafe_allow_html=True)
     col4.markdown("&#x200B;")
+    col5.markdown("&#x200B;")
 
     for model in models:
         model_id = model["id"]
@@ -375,6 +409,13 @@ def render_model_rows(model_type: str) -> None:
                 "model_provider": model_provider,
             },
         )
+        if model_provider == "ollama" and not model.get("usable", False):
+            col5.button(
+                "Pull",
+                on_click=pull_model_dialog,
+                key=f"runtime_{model_type}_{model_provider}_{model_id}_pull",
+                kwargs={"provider": model_provider, "model_id": model_id},
+            )
 
     if st.button(label="Add", type="primary", key=f"add_{model_type}_model"):
         edit_model(model_type=model_type, action="add")

--- a/src/client/app/core/api.py
+++ b/src/client/app/core/api.py
@@ -216,17 +216,19 @@ def api_post_stream(
 ) -> Generator[dict, None, None]:
     """Streaming POST request to the API server. Yields parsed NDJSON dicts."""
     url = f"{_base_url(api_prefix)}/{path.lstrip('/')}"
-    with httpx.Client(headers=_headers(), timeout=timeout) as client:
-        with client.stream("POST", url, json=json_body) as resp:
-            resp.raise_for_status()
-            for line in resp.iter_lines():
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    yield json.loads(line)
-                except json.JSONDecodeError:
-                    continue
+    with (
+        httpx.Client(headers=_headers(), timeout=timeout) as client,
+        client.stream("POST", url, json=json_body) as resp,
+    ):
+        resp.raise_for_status()
+        for raw_line in resp.iter_lines():
+            stripped = raw_line.strip()
+            if not stripped:
+                continue
+            try:
+                yield json.loads(stripped)
+            except json.JSONDecodeError:
+                continue
 
 
 def api_put(

--- a/src/client/app/core/api.py
+++ b/src/client/app/core/api.py
@@ -5,12 +5,14 @@ Licensed under the Universal Permissive License v1.0 as shown at http://oss.orac
 # spell-checker:ignore apiserver pypath
 
 import atexit
+import json
 import logging
 import os
 import secrets
 import subprocess
 import sys
 import time
+from collections.abc import Generator
 from io import TextIOWrapper
 from pathlib import Path
 from typing import Any
@@ -204,6 +206,27 @@ def api_post(
         if toast:
             st.toast(toast, icon="✅")
         return resp.json()
+
+
+def api_post_stream(
+    path: str,
+    json_body: dict | None = None,
+    timeout: int = 600,
+    api_prefix: str = "/v1",
+) -> Generator[dict, None, None]:
+    """Streaming POST request to the API server. Yields parsed NDJSON dicts."""
+    url = f"{_base_url(api_prefix)}/{path.lstrip('/')}"
+    with httpx.Client(headers=_headers(), timeout=timeout) as client:
+        with client.stream("POST", url, json=json_body) as resp:
+            resp.raise_for_status()
+            for line in resp.iter_lines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    yield json.loads(line)
+                except json.JSONDecodeError:
+                    continue
 
 
 def api_put(

--- a/src/client/tests/content/config/tabs/test_models.py
+++ b/src/client/tests/content/config/tabs/test_models.py
@@ -998,7 +998,7 @@ class TestRenderModelRows:
         ]
         state = make_model_state(model_configs=configs)
 
-        cols = [MagicMock(), MagicMock(), MagicMock(), MagicMock()]
+        cols = [MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock()]
         mock_st.columns.side_effect = lambda widths, **kw: cols
         mock_st.button.return_value = False
 
@@ -1020,7 +1020,7 @@ class TestRenderModelRows:
         ]
         state = make_model_state(model_configs=configs)
 
-        cols = [MagicMock(), MagicMock(), MagicMock(), MagicMock()]
+        cols = [MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock()]
         mock_st.columns.side_effect = lambda widths, **kw: cols
         mock_st.button.return_value = False
 

--- a/src/server/app/api/v1/endpoints/models.py
+++ b/src/server/app/api/v1/endpoints/models.py
@@ -6,15 +6,18 @@ Endpoints for retrieving model configurations.
 """
 # spell-checker:ignore litellm ollama rerank
 
+import json
 from typing import Optional
 
 import litellm
 from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import StreamingResponse
 
 from server.app.core.settings import _settings_lock, settings
 from server.app.database.settings import persist_settings
 from server.app.models.connectivity import check_single_model
 from server.app.models.litellm_utils import find_model
+from server.app.models.ollama import pull_ollama_model
 from server.app.models.schemas import ModelConfig, ModelSensitive, ModelUpdate, SupportedProviderIds
 
 litellm.suppress_debug_info = True
@@ -98,6 +101,35 @@ async def models_supported(
 ) -> list[SupportedProviderIds]:
     """List supported providers and models from LiteLLM."""
     return _get_supported(model_provider=model_provider, model_type=model_type)
+
+
+# --- Pull endpoint (must be before /{provider}/{model_id:path}) ---
+
+
+@auth.post("/pull/{provider}/{model_id:path}")
+async def pull_model(provider: str, model_id: str):
+    """Pull an Ollama model and stream progress as NDJSON."""
+    if provider.casefold() != "ollama":
+        raise HTTPException(status_code=400, detail="Pull is only supported for Ollama models")
+
+    cfg = _find_model(provider, model_id)
+    if cfg is None:
+        raise HTTPException(status_code=404, detail=f"Model config not found: {provider}/{model_id}")
+    if not cfg.api_base:
+        raise HTTPException(status_code=400, detail=f"Model {provider}/{model_id} has no API base URL configured")
+
+    async def _stream():
+        error_occurred = False
+        async for event in pull_ollama_model(cfg.api_base, model_id):
+            if "error" in event:
+                error_occurred = True
+            yield json.dumps(event) + "\n"
+        if not error_occurred:
+            await check_single_model(cfg)
+            await persist_settings()
+            yield json.dumps({"status": "success"}) + "\n"
+
+    return StreamingResponse(_stream(), media_type="application/x-ndjson")
 
 
 @auth.get("/{provider}/{model_id:path}", response_model=ModelConfig, response_model_exclude_unset=True)

--- a/src/server/app/api/v1/endpoints/models.py
+++ b/src/server/app/api/v1/endpoints/models.py
@@ -127,8 +127,10 @@ async def pull_model(provider: str, model_id: str):
             yield json.dumps(event) + "\n"
         if not error_occurred:
             await check_single_model(cfg)
-            await persist_settings()
-            yield json.dumps({"status": "success"}) + "\n"
+            if not await persist_settings():
+                yield json.dumps({"error": _PERSIST_FAIL}) + "\n"
+            else:
+                yield json.dumps({"status": "success"}) + "\n"
 
     return StreamingResponse(_stream(), media_type="application/x-ndjson")
 

--- a/src/server/app/api/v1/endpoints/models.py
+++ b/src/server/app/api/v1/endpoints/models.py
@@ -117,10 +117,11 @@ async def pull_model(provider: str, model_id: str):
         raise HTTPException(status_code=404, detail=f"Model config not found: {provider}/{model_id}")
     if not cfg.api_base:
         raise HTTPException(status_code=400, detail=f"Model {provider}/{model_id} has no API base URL configured")
+    api_base: str = cfg.api_base
 
     async def _stream():
         error_occurred = False
-        async for event in pull_ollama_model(cfg.api_base, model_id):
+        async for event in pull_ollama_model(api_base, model_id):
             if "error" in event:
                 error_occurred = True
             yield json.dumps(event) + "\n"

--- a/src/server/app/models/ollama.py
+++ b/src/server/app/models/ollama.py
@@ -6,8 +6,10 @@ Ollama model discovery — queries a running Ollama server for pulled models.
 """
 # spell-checker: ignore ollama nomic
 
+import json
 import logging
 import os
+from collections.abc import AsyncGenerator
 
 import httpx
 
@@ -129,3 +131,29 @@ async def load_ollama_models() -> None:
         LOGGER.info("Removed %d Ollama model(s) no longer pulled", len(removed))
 
     LOGGER.info("Discovered %d Ollama model(s) at %s", len(models), api_base)
+
+
+async def pull_ollama_model(api_base: str, model_name: str) -> AsyncGenerator[dict, None]:
+    """Stream pull progress from an Ollama server as dicts.
+
+    Each yielded dict mirrors the NDJSON lines from Ollama's ``/api/pull``
+    endpoint (keys like ``status``, ``completed``, ``total``, ``digest``).
+    On error an ``{"error": "..."}`` dict is yielded.
+    """
+    url = f"{api_base.rstrip('/')}/api/pull"
+    pull_read_timeout = 120.0  # Longer timeout for pull — gaps between progress lines during layer downloads
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(pull_read_timeout, connect=CONNECT_TIMEOUT)) as client:
+            async with client.stream("POST", url, json={"name": model_name}) as resp:
+                resp.raise_for_status()
+                async for line in resp.aiter_lines():
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        yield json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+    except httpx.HTTPError as exc:
+        LOGGER.warning("Ollama pull failed for '%s' at %s: %s", model_name, api_base, exc)
+        yield {"error": str(exc)}

--- a/src/server/app/models/ollama.py
+++ b/src/server/app/models/ollama.py
@@ -143,19 +143,17 @@ async def pull_ollama_model(api_base: str, model_name: str) -> AsyncGenerator[di
     url = f"{api_base.rstrip('/')}/api/pull"
     pull_read_timeout = 120.0  # Longer timeout for pull — gaps between progress lines during layer downloads
     try:
-        async with (
-            httpx.AsyncClient(timeout=httpx.Timeout(pull_read_timeout, connect=CONNECT_TIMEOUT)) as client,
-            client.stream("POST", url, json={"name": model_name}) as resp,
-        ):
-            resp.raise_for_status()
-            async for raw_line in resp.aiter_lines():
-                stripped = raw_line.strip()
-                if not stripped:
-                    continue
-                try:
-                    yield json.loads(stripped)
-                except json.JSONDecodeError:
-                    continue
+        async with httpx.AsyncClient(timeout=httpx.Timeout(pull_read_timeout, connect=CONNECT_TIMEOUT)) as client:  # noqa: SIM117
+            async with client.stream("POST", url, json={"name": model_name}) as resp:
+                resp.raise_for_status()
+                async for raw_line in resp.aiter_lines():
+                    stripped = raw_line.strip()
+                    if not stripped:
+                        continue
+                    try:
+                        yield json.loads(stripped)
+                    except json.JSONDecodeError:
+                        continue
     except httpx.HTTPError as exc:
         LOGGER.warning("Ollama pull failed for '%s' at %s: %s", model_name, api_base, exc)
         yield {"error": str(exc)}

--- a/src/server/app/models/ollama.py
+++ b/src/server/app/models/ollama.py
@@ -143,17 +143,19 @@ async def pull_ollama_model(api_base: str, model_name: str) -> AsyncGenerator[di
     url = f"{api_base.rstrip('/')}/api/pull"
     pull_read_timeout = 120.0  # Longer timeout for pull — gaps between progress lines during layer downloads
     try:
-        async with httpx.AsyncClient(timeout=httpx.Timeout(pull_read_timeout, connect=CONNECT_TIMEOUT)) as client:
-            async with client.stream("POST", url, json={"name": model_name}) as resp:
-                resp.raise_for_status()
-                async for line in resp.aiter_lines():
-                    line = line.strip()
-                    if not line:
-                        continue
-                    try:
-                        yield json.loads(line)
-                    except json.JSONDecodeError:
-                        continue
+        async with (
+            httpx.AsyncClient(timeout=httpx.Timeout(pull_read_timeout, connect=CONNECT_TIMEOUT)) as client,
+            client.stream("POST", url, json={"name": model_name}) as resp,
+        ):
+            resp.raise_for_status()
+            async for raw_line in resp.aiter_lines():
+                stripped = raw_line.strip()
+                if not stripped:
+                    continue
+                try:
+                    yield json.loads(stripped)
+                except json.JSONDecodeError:
+                    continue
     except httpx.HTTPError as exc:
         LOGGER.warning("Ollama pull failed for '%s' at %s: %s", model_name, api_base, exc)
         yield {"error": str(exc)}

--- a/src/server/tests/api/test_v1_models_pull.py
+++ b/src/server/tests/api/test_v1_models_pull.py
@@ -1,0 +1,164 @@
+"""
+Copyright (c) 2024, 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
+
+Tests for the POST /v1/models/pull/{provider}/{model_id} endpoint.
+"""
+# spell-checker: disable
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from server.app.core.settings import settings
+from server.app.models.schemas import ModelConfig
+
+OLLAMA_URL = "http://localhost:11434"
+
+
+@pytest.fixture(autouse=True)
+def _populate_configs():
+    """Inject test ModelConfig entries including an Ollama model."""
+    original = settings.model_configs
+    settings.model_configs = [
+        ModelConfig(
+            id="qwen3:8b",
+            type="ll",
+            provider="ollama",
+            api_base=OLLAMA_URL,
+        ),
+        ModelConfig(
+            id="test-llm",
+            type="ll",
+            provider="openai",
+            api_key="sk-secret",
+        ),
+        ModelConfig(
+            id="no-base",
+            type="ll",
+            provider="ollama",
+        ),
+    ]
+    yield
+    settings.model_configs = original
+
+
+@pytest.fixture(autouse=True)
+def mock_persist_settings():
+    """Prevent persist_settings from doing real DB I/O."""
+    with patch("server.app.api.v1.endpoints.models.persist_settings", new_callable=AsyncMock, return_value=True):
+        yield
+
+
+async def _collect_ndjson(response) -> list[dict]:
+    """Collect parsed NDJSON events from a streaming response."""
+    events = []
+    async for line in response.aiter_lines():
+        stripped = line.strip()
+        if stripped:
+            events.append(json.loads(stripped))
+    return events
+
+
+async def _fake_pull_success(*_args, **_kwargs):
+    yield {"status": "pulling manifest"}
+    yield {"status": "downloading", "completed": 500, "total": 1000}
+    yield {"status": "downloading", "completed": 1000, "total": 1000}
+
+
+async def _fake_pull_error(*_args, **_kwargs):
+    yield {"status": "pulling manifest"}
+    yield {"error": "model not found"}
+
+
+# --- Happy path ---
+
+
+@pytest.mark.unit
+@pytest.mark.anyio
+async def test_pull_model_streams_progress(app_client, auth_headers):
+    """POST pull returns 200 and streams NDJSON progress."""
+    with patch("server.app.api.v1.endpoints.models.pull_ollama_model", side_effect=_fake_pull_success):
+        resp = await app_client.post("/v1/models/pull/ollama/qwen3:8b", headers=auth_headers)
+
+    assert resp.status_code == 200
+    assert "application/x-ndjson" in resp.headers["content-type"]
+
+    events = await _collect_ndjson(resp)
+    statuses = [e.get("status") for e in events]
+    assert "pulling manifest" in statuses
+    assert "success" in statuses
+
+
+@pytest.mark.unit
+@pytest.mark.anyio
+async def test_pull_model_calls_check_and_persist(app_client, auth_headers):
+    """After successful pull, check_single_model and persist_settings are called."""
+    with (
+        patch("server.app.api.v1.endpoints.models.pull_ollama_model", side_effect=_fake_pull_success),
+        patch("server.app.api.v1.endpoints.models.check_single_model", new_callable=AsyncMock) as mock_check,
+        patch("server.app.api.v1.endpoints.models.persist_settings", new_callable=AsyncMock, return_value=True) as mock_persist,
+    ):
+        resp = await app_client.post("/v1/models/pull/ollama/qwen3:8b", headers=auth_headers)
+        # Consume the stream to trigger the post-pull logic
+        _ = await _collect_ndjson(resp)
+
+    mock_check.assert_called_once()
+    mock_persist.assert_called_once()
+
+
+# --- Error from Ollama ---
+
+
+@pytest.mark.unit
+@pytest.mark.anyio
+async def test_pull_model_error_no_success_event(app_client, auth_headers):
+    """When Ollama returns an error, no 'success' event is emitted."""
+    with patch("server.app.api.v1.endpoints.models.pull_ollama_model", side_effect=_fake_pull_error):
+        resp = await app_client.post("/v1/models/pull/ollama/qwen3:8b", headers=auth_headers)
+
+    events = await _collect_ndjson(resp)
+    statuses = [e.get("status") for e in events]
+    assert "success" not in statuses
+    assert any("error" in e for e in events)
+
+
+# --- Validation errors ---
+
+
+@pytest.mark.unit
+@pytest.mark.anyio
+async def test_pull_non_ollama_returns_400(app_client, auth_headers):
+    """Pull is only supported for Ollama models."""
+    resp = await app_client.post("/v1/models/pull/openai/test-llm", headers=auth_headers)
+    assert resp.status_code == 400
+    assert "Ollama" in resp.json()["detail"]
+
+
+@pytest.mark.unit
+@pytest.mark.anyio
+async def test_pull_unknown_model_returns_404(app_client, auth_headers):
+    """Pull for a model not in config returns 404."""
+    resp = await app_client.post("/v1/models/pull/ollama/nonexistent", headers=auth_headers)
+    assert resp.status_code == 404
+
+
+@pytest.mark.unit
+@pytest.mark.anyio
+async def test_pull_no_api_base_returns_400(app_client, auth_headers):
+    """Pull for an Ollama model with no api_base returns 400."""
+    resp = await app_client.post("/v1/models/pull/ollama/no-base", headers=auth_headers)
+    assert resp.status_code == 400
+    assert "API base URL" in resp.json()["detail"]
+
+
+# --- Auth ---
+
+
+@pytest.mark.unit
+@pytest.mark.anyio
+async def test_pull_model_no_auth(app_client):
+    """Pull without auth returns 403."""
+    resp = await app_client.post("/v1/models/pull/ollama/qwen3:8b")
+    assert resp.status_code == 403

--- a/src/server/tests/api/test_v1_models_pull.py
+++ b/src/server/tests/api/test_v1_models_pull.py
@@ -110,6 +110,27 @@ async def test_pull_model_calls_check_and_persist(app_client, auth_headers):
     mock_persist.assert_called_once()
 
 
+# --- Persist failure ---
+
+
+@pytest.mark.unit
+@pytest.mark.anyio
+async def test_pull_model_persist_failure_emits_error(app_client, auth_headers):
+    """When persist_settings returns False, an error event is emitted instead of success."""
+    with (
+        patch("server.app.api.v1.endpoints.models.pull_ollama_model", side_effect=_fake_pull_success),
+        patch("server.app.api.v1.endpoints.models.check_single_model", new_callable=AsyncMock),
+        patch("server.app.api.v1.endpoints.models.persist_settings", new_callable=AsyncMock, return_value=False),
+    ):
+        resp = await app_client.post("/v1/models/pull/ollama/qwen3:8b", headers=auth_headers)
+
+    events = await _collect_ndjson(resp)
+    statuses = [e.get("status") for e in events]
+    assert "success" not in statuses
+    assert any("error" in e for e in events)
+    assert any("persist" in e.get("error", "").lower() for e in events if "error" in e)
+
+
 # --- Error from Ollama ---
 
 

--- a/src/server/tests/api/test_v1_models_pull.py
+++ b/src/server/tests/api/test_v1_models_pull.py
@@ -98,7 +98,9 @@ async def test_pull_model_calls_check_and_persist(app_client, auth_headers):
     with (
         patch("server.app.api.v1.endpoints.models.pull_ollama_model", side_effect=_fake_pull_success),
         patch("server.app.api.v1.endpoints.models.check_single_model", new_callable=AsyncMock) as mock_check,
-        patch("server.app.api.v1.endpoints.models.persist_settings", new_callable=AsyncMock, return_value=True) as mock_persist,
+        patch(
+            "server.app.api.v1.endpoints.models.persist_settings", new_callable=AsyncMock, return_value=True
+        ) as mock_persist,
     ):
         resp = await app_client.post("/v1/models/pull/ollama/qwen3:8b", headers=auth_headers)
         # Consume the stream to trigger the post-pull logic

--- a/src/server/tests/models/test_ollama_pull.py
+++ b/src/server/tests/models/test_ollama_pull.py
@@ -1,0 +1,141 @@
+"""
+Copyright (c) 2024, 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
+
+Tests for server.app.models.ollama.pull_ollama_model.
+"""
+# spell-checker: disable
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from server.app.models.ollama import pull_ollama_model
+
+OLLAMA_URL = "http://localhost:11434"
+
+
+def _make_stream_response(lines: list[str]):
+    """Return a mock response whose aiter_lines yields the given lines."""
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+
+    async def _aiter():
+        for item in lines:
+            yield item
+
+    resp.aiter_lines = _aiter
+    return resp
+
+
+def _patch_client(stream_resp):
+    """Patch httpx.AsyncClient to return a mock that yields stream_resp from .stream()."""
+    mock_cls = patch("server.app.models.ollama.httpx.AsyncClient")
+    mock = mock_cls.start()
+    client = MagicMock()
+    mock.return_value.__aenter__ = AsyncMock(return_value=client)
+    mock.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    # client.stream() is a sync call returning an async context manager
+    stream_ctx = MagicMock()
+    stream_ctx.__aenter__ = AsyncMock(return_value=stream_resp)
+    stream_ctx.__aexit__ = AsyncMock(return_value=False)
+    client.stream.return_value = stream_ctx
+
+    return mock_cls, client
+
+
+class TestPullOllamaModel:
+    """Tests for pull_ollama_model async generator."""
+
+    @pytest.mark.anyio
+    async def test_streams_progress(self):
+        """Yields parsed NDJSON progress dicts from Ollama."""
+        ndjson_lines = [
+            '{"status": "pulling manifest"}',
+            '{"status": "downloading", "completed": 500, "total": 1000}',
+            '{"status": "downloading", "completed": 1000, "total": 1000}',
+            '{"status": "success"}',
+        ]
+        resp = _make_stream_response(ndjson_lines)
+        patcher, _ = _patch_client(resp)
+        try:
+            events = [event async for event in pull_ollama_model(OLLAMA_URL, "qwen3:8b")]
+        finally:
+            patcher.stop()
+
+        assert len(events) == 4
+        assert events[0] == {"status": "pulling manifest"}
+        assert events[1]["completed"] == 500
+        assert events[3] == {"status": "success"}
+
+    @pytest.mark.anyio
+    async def test_skips_empty_lines(self):
+        """Empty and whitespace-only lines are skipped."""
+        ndjson_lines = ['{"status": "pulling"}', "", "  ", '{"status": "done"}']
+        resp = _make_stream_response(ndjson_lines)
+        patcher, _ = _patch_client(resp)
+        try:
+            events = [event async for event in pull_ollama_model(OLLAMA_URL, "qwen3:8b")]
+        finally:
+            patcher.stop()
+
+        assert len(events) == 2
+
+    @pytest.mark.anyio
+    async def test_skips_invalid_json(self):
+        """Lines that aren't valid JSON are silently skipped."""
+        ndjson_lines = ['{"status": "pulling"}', "not-json", '{"status": "done"}']
+        resp = _make_stream_response(ndjson_lines)
+        patcher, _ = _patch_client(resp)
+        try:
+            events = [event async for event in pull_ollama_model(OLLAMA_URL, "qwen3:8b")]
+        finally:
+            patcher.stop()
+
+        assert len(events) == 2
+
+    @pytest.mark.anyio
+    async def test_http_error_yields_error_dict(self):
+        """On httpx.HTTPError, yields a single error dict."""
+        with patch("server.app.models.ollama.httpx.AsyncClient") as mock_cls:
+            client = MagicMock()
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            client.stream.side_effect = httpx.ConnectError("refused")
+
+            events = [event async for event in pull_ollama_model(OLLAMA_URL, "qwen3:8b")]
+
+        assert len(events) == 1
+        assert "error" in events[0]
+        assert "refused" in events[0]["error"]
+
+    @pytest.mark.anyio
+    async def test_calls_correct_url(self):
+        """Verifies the pull hits /api/pull with the correct model name."""
+        resp = _make_stream_response(['{"status": "success"}'])
+        patcher, client = _patch_client(resp)
+        try:
+            _ = [event async for event in pull_ollama_model(OLLAMA_URL, "qwen3:8b")]
+        finally:
+            patcher.stop()
+
+        client.stream.assert_called_once_with(
+            "POST",
+            f"{OLLAMA_URL}/api/pull",
+            json={"name": "qwen3:8b"},
+        )
+
+    @pytest.mark.anyio
+    async def test_trailing_slash_stripped(self):
+        """Trailing slash on api_base doesn't produce double-slash in URL."""
+        resp = _make_stream_response(['{"status": "success"}'])
+        patcher, client = _patch_client(resp)
+        try:
+            _ = [event async for event in pull_ollama_model(f"{OLLAMA_URL}/", "qwen3:8b")]
+        finally:
+            patcher.stop()
+
+        call_url = client.stream.call_args[0][1]
+        assert "//" not in call_url.replace("http://", "")


### PR DESCRIPTION

Adds a Pull button to each Ollama model row in the Models config page, allowing users to download models directly from the GUI without needing to run ollama pull manually.

  Changes:
  - POST /v1/models/pull/{provider}/{model_id} endpoint streams Ollama pull progress as NDJSON
  - Pull dialog shows live download progress (single updating line, not a flood of lines)
  - Enabling an Ollama model is blocked with a clear error if the model hasn't been pulled yet
  - Model list now always reflects current enabled/disabled state immediately after save