### PR TITLE
Fix OCI OpenAI chat parameters and OCI auth/model kwargs

### DIFF
--- a/src/server/app/models/litellm_utils.py
+++ b/src/server/app/models/litellm_utils.py
@@ -8,7 +8,7 @@ LiteLLM configuration builder and embedding client factory.
 
 import logging
 import re
-from typing import Optional
+from typing import Any, Dict, Optional
 from urllib.parse import urlparse
 
 import litellm
@@ -105,6 +105,67 @@ def find_model(
 _PENALTY_UNSUPPORTED_PATTERNS = ("xai", "ollama")
 
 
+def uses_max_completion_tokens(model_key: str) -> bool:
+    """Return True when a model rejects ``max_tokens`` in favor of ``max_completion_tokens``."""
+    model_lower = model_key.lower()
+    if model_lower.startswith("oci/"):
+        model_lower = model_lower.split("/", 1)[1]
+    if model_lower.startswith("openai/"):
+        model_lower = model_lower.split("/", 1)[1]
+    elif model_lower.startswith("openai."):
+        model_lower = model_lower.removeprefix("openai.")
+    return model_lower.startswith(("gpt-5", "o1", "o3", "o4"))
+
+
+def normalize_completion_token_params(model_key: Optional[str], params: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize generation params for models with restricted OpenAI-compatible controls."""
+    resolved_model = model_key or str(params.get("model") or "")
+    provider = str(params.get("custom_llm_provider") or "").lower()
+    uses_completion_tokens = uses_max_completion_tokens(resolved_model) or (
+        provider == "oci" and uses_max_completion_tokens(str(params.get("model") or ""))
+    )
+    if params.get("max_tokens") is not None and uses_completion_tokens:
+        params["max_completion_tokens"] = params["max_tokens"]
+        params.pop("max_tokens", None)
+    if uses_completion_tokens:
+        params.pop("temperature", None)
+        params.pop("top_p", None)
+        params.pop("frequency_penalty", None)
+        params.pop("presence_penalty", None)
+    return params
+
+
+def patch_litellm_oci_openai_max_completion_tokens() -> None:
+    """Patch LiteLLM's OCI payload for OpenAI models that reject ``maxTokens``.
+
+    LiteLLM maps both ``max_tokens`` and ``max_completion_tokens`` to OCI's
+    ``maxTokens`` field. OCI GenericChatRequest also supports
+    ``maxCompletionTokens``, which OpenAI GPT-5/o-series models require.
+    """
+    try:
+        from litellm.llms.oci.chat.transformation import OCIChatConfig
+    except Exception:
+        return
+
+    if getattr(OCIChatConfig, "_aio_max_completion_patch", False):
+        return
+
+    original_transform_request = OCIChatConfig.transform_request
+
+    def transform_request_with_max_completion_tokens(self, model, messages, optional_params, litellm_params, headers):
+        data = original_transform_request(self, model, messages, optional_params, litellm_params, headers)
+        chat_request = data.get("chatRequest")
+        if uses_max_completion_tokens(model) and isinstance(chat_request, dict) and "maxTokens" in chat_request:
+            chat_request["maxCompletionTokens"] = chat_request.pop("maxTokens")
+        return data
+
+    OCIChatConfig.transform_request = transform_request_with_max_completion_tokens
+    OCIChatConfig._aio_max_completion_patch = True
+
+
+patch_litellm_oci_openai_max_completion_tokens()
+
+
 def strip_unsupported_penalties(
     model_key: str,
     frequency_penalty: Optional[float],
@@ -137,9 +198,12 @@ def build_oci_litellm_params(oci_profile: OciProfileConfig) -> dict:
                 "oci_tenancy": oci_profile.tenancy,
                 "oci_user": oci_profile.user,
                 "oci_fingerprint": oci_profile.fingerprint,
-                "oci_key_file": oci_profile.key_file,
             }
         )
+        if oci_profile.key_content:
+            params["oci_key"] = reveal(oci_profile.key_content)
+        elif oci_profile.key_file:
+            params["oci_key_file"] = oci_profile.key_file
     return params
 
 
@@ -264,14 +328,19 @@ class LiteLlmModelSpec:
         for param_name, value in [
             ("temperature", self.temperature),
             ("top_p", self.top_p),
-            ("max_tokens", self.max_tokens),
             ("frequency_penalty", self.frequency_penalty),
             ("presence_penalty", self.presence_penalty),
         ]:
             if value is not None and param_name in supported_params:
                 kwargs[param_name] = value
+        if self.max_tokens is not None:
+            if uses_max_completion_tokens(self.model_key):
+                kwargs["max_completion_tokens"] = self.max_tokens
+            elif "max_tokens" in supported_params:
+                kwargs["max_tokens"] = self.max_tokens
 
         kwargs["model"] = self.model_key
+        normalize_completion_token_params(self.model_key, kwargs)
         # LiteLLM's ollama provider breaks tool call parsing when api_base is
         # passed as a call parameter; base_url works correctly for all providers.
         if self.api_base:

--- a/src/server/app/runtime/common.py
+++ b/src/server/app/runtime/common.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel
 from server.app.agentspec.adapters.mcp import fetch_mcp_prompt
 from server.app.api.v1.schemas.chat import TokenUsage, VsMetadata
 from server.app.core.schemas import TOOL_NL2SQL, TOOL_VECSEARCH
+from server.app.models.litellm_utils import normalize_completion_token_params
 
 LOGGER = logging.getLogger(__name__)
 
@@ -303,13 +304,19 @@ class BaseCombinedSession:
         """Classify a query as 'nl2sql', 'vecsearch', or 'both'."""
         prompt = CLASSIFIER_PROMPT.replace("{{query}}", query)
         try:
+            completion_kwargs = normalize_completion_token_params(
+                self._classifier_model,
+                {
+                    "model": self._classifier_model,
+                    "messages": [{"role": "user", "content": prompt}],
+                    "max_tokens": 10,
+                    "temperature": 0.0,
+                    "drop_params": True,
+                    **self._auth_kwargs(),
+                },
+            )
             response = await litellm.acompletion(
-                model=self._classifier_model,
-                messages=[{"role": "user", "content": prompt}],
-                max_tokens=10,
-                temperature=0.0,
-                drop_params=True,
-                **self._auth_kwargs(),
+                **completion_kwargs,
             )
             if not isinstance(response, ModelResponse):
                 raise TypeError(f"Expected ModelResponse, got {type(response)}")

--- a/src/server/app/runtime/langgraph/adapters/litellm.py
+++ b/src/server/app/runtime/langgraph/adapters/litellm.py
@@ -37,7 +37,7 @@ from langchain_litellm import ChatLiteLLM
 from pydantic import BaseModel
 
 from server.app.api.v1.schemas.chat import TokenUsage
-from server.app.models.litellm_utils import LiteLlmModelSpec
+from server.app.models.litellm_utils import LiteLlmModelSpec, normalize_completion_token_params
 from server.app.runtime.ollama_tools import (
     contextualize_tool_result,
     is_ollama_model,
@@ -286,7 +286,8 @@ class OracleChatLiteLLM(ChatLiteLLM):
         name_map = kwargs.pop(_OLLAMA_NAME_MAP_KEY, None)
         yielded_any = False
         try:
-            for chunk in super()._stream(messages, stop=stop, run_manager=run_manager, **kwargs):
+            stream_kwargs = normalize_completion_token_params(self.model, dict(kwargs))
+            for chunk in super()._stream(messages, stop=stop, run_manager=run_manager, **stream_kwargs):
                 _flatten_chunk_content(chunk)
                 _unsanitize_chunk_tool_calls(chunk, name_map)
                 yielded_any = True
@@ -312,7 +313,8 @@ class OracleChatLiteLLM(ChatLiteLLM):
         name_map = kwargs.pop(_OLLAMA_NAME_MAP_KEY, None)
         yielded_any = False
         try:
-            async for chunk in super()._astream(messages, stop=stop, run_manager=run_manager, **kwargs):
+            stream_kwargs = normalize_completion_token_params(self.model, dict(kwargs))
+            async for chunk in super()._astream(messages, stop=stop, run_manager=run_manager, **stream_kwargs):
                 _flatten_chunk_content(chunk)
                 _unsanitize_chunk_tool_calls(chunk, name_map)
                 yielded_any = True
@@ -370,6 +372,7 @@ class OracleChatLiteLLM(ChatLiteLLM):
         """
         message_dicts, params = self._create_message_dicts(messages, stop)
         params = {**params, **kwargs, "stream": False}
+        normalize_completion_token_params(self.model, params)
         return message_dicts, params
 
     def _fallback_non_streaming(
@@ -387,6 +390,15 @@ class OracleChatLiteLLM(ChatLiteLLM):
         )
         return self._create_chat_result(response)
 
+    def completion_with_retry(
+        self,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Final parameter normalization before LiteLLM's sync completion call."""
+        normalize_completion_token_params(self.model, kwargs)
+        return super().completion_with_retry(run_manager=run_manager, **kwargs)
+
     async def _afallback_non_streaming(
         self,
         messages: List[BaseMessage],
@@ -401,6 +413,15 @@ class OracleChatLiteLLM(ChatLiteLLM):
             **params,
         )
         return self._create_chat_result(response)
+
+    async def acompletion_with_retry(
+        self,
+        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Final parameter normalization before LiteLLM's async completion call."""
+        normalize_completion_token_params(self.model, kwargs)
+        return await super().acompletion_with_retry(run_manager=run_manager, **kwargs)
 
     @property
     def _client_params(self) -> Dict[str, Any]:
@@ -427,6 +448,7 @@ class OracleChatLiteLLM(ChatLiteLLM):
            AgentSpec's ``LanguageModelParameters`` carries through).
         """
         params = dict(self._default_params)
+        params.update(self.model_kwargs or {})
         params["drop_params"] = True
         if self.top_p is not None:
             params["top_p"] = self.top_p
@@ -434,7 +456,7 @@ class OracleChatLiteLLM(ChatLiteLLM):
             params["api_key"] = self.api_key
         if self.api_base:
             params["base_url"] = self.api_base
-        return params
+        return normalize_completion_token_params(self.model, params)
 
     @property
     def _llm_type(self) -> str:

--- a/src/server/tests/models/test_litellm_utils.py
+++ b/src/server/tests/models/test_litellm_utils.py
@@ -19,6 +19,9 @@ from server.app.models.litellm_utils import (
     find_model,
     get_client_embed,
     is_small_model,
+    normalize_completion_token_params,
+    patch_litellm_oci_openai_max_completion_tokens,
+    uses_max_completion_tokens,
 )
 from server.app.models.schemas import ModelConfig, ModelIdentity
 from server.app.oci.schemas import OciProfileConfig
@@ -289,6 +292,81 @@ def test_to_litellm_kwargs_basic():
 
 
 @pytest.mark.unit
+def test_to_litellm_kwargs_oci_openai_gpt5_uses_max_completion_tokens():
+    """OCI OpenAI GPT-5 models reject max_tokens and require max_completion_tokens."""
+    mc = ModelConfig(id="openai.gpt-5.5", type="ll", provider="oci", max_tokens=1234, enabled=True)
+    settings.model_configs = [mc]
+
+    with (
+        patch("server.app.models.litellm_utils.litellm") as mock_litellm,
+        patch("server.app.models.litellm_utils.get_signer", return_value=None),
+    ):
+        mock_litellm.get_supported_openai_params.return_value = ["max_tokens"]
+        spec = LiteLlmModelSpec("oci", "openai.gpt-5.5", oci_profile=_oci_profile())
+        result = spec.to_litellm_kwargs()
+
+    assert result["max_completion_tokens"] == 1234
+    assert "max_tokens" not in result
+
+
+@pytest.mark.unit
+def test_uses_max_completion_tokens_model_key_rules():
+    assert uses_max_completion_tokens("oci/openai.gpt-5.5")
+    assert uses_max_completion_tokens("oci/openai/gpt-5.5")
+    assert uses_max_completion_tokens("openai.gpt-5.5")
+    assert uses_max_completion_tokens("openai/gpt-5.5")
+    assert uses_max_completion_tokens("oci/openai.o3")
+    assert not uses_max_completion_tokens("oci/openai.gpt-4o")
+    assert not uses_max_completion_tokens("oci/cohere.command-r")
+
+
+@pytest.mark.unit
+def test_normalize_completion_token_params_uses_model_from_params():
+    params = {"model": "oci/openai.gpt-5.5", "max_tokens": 99}
+    result = normalize_completion_token_params(None, params)
+    assert result["max_completion_tokens"] == 99
+    assert "max_tokens" not in result
+
+
+@pytest.mark.unit
+def test_normalize_completion_token_params_uses_custom_oci_provider_context():
+    params = {
+        "model": "openai.gpt-5.5",
+        "custom_llm_provider": "oci",
+        "max_tokens": 99,
+        "temperature": 0.0,
+        "top_p": 0.5,
+        "frequency_penalty": 0.1,
+        "presence_penalty": 0.2,
+    }
+    result = normalize_completion_token_params(None, params)
+    assert result["max_completion_tokens"] == 99
+    assert "max_tokens" not in result
+    assert "temperature" not in result
+    assert "top_p" not in result
+    assert "frequency_penalty" not in result
+    assert "presence_penalty" not in result
+
+
+@pytest.mark.unit
+def test_litellm_oci_openai_gpt5_payload_uses_max_completion_tokens():
+    from litellm.llms.oci.chat.transformation import OCIChatConfig
+
+    patch_litellm_oci_openai_max_completion_tokens()
+    payload = OCIChatConfig().transform_request(
+        "openai.gpt-5.5",
+        [{"role": "user", "content": "hi"}],
+        {"oci_compartment_id": "ocid1.compartment.oc1..test", "maxTokens": 99},
+        {},
+        {},
+    )
+
+    chat_request = payload["chatRequest"]
+    assert chat_request["maxCompletionTokens"] == 99
+    assert "maxTokens" not in chat_request
+
+
+@pytest.mark.unit
 def test_to_litellm_kwargs_ollama():
     """Ollama LL model keeps ollama/ prefix in kwargs."""
     mc = ModelConfig(id="qwen3:8b", type="ll", provider="ollama", enabled=True)
@@ -359,6 +437,27 @@ def test_to_litellm_kwargs_oci_without_signer():
     assert result["oci_fingerprint"] == "aa:bb:cc"
     assert result["oci_key_file"] == "/path/to/key"
     assert "oci_signer" not in result
+
+
+@pytest.mark.unit
+def test_to_litellm_kwargs_oci_with_inline_key_content():
+    """OCI provider maps inline key content to LiteLLM's ``oci_key`` parameter."""
+    mc = ModelConfig(id="cohere.command-r", type="ll", provider="oci", enabled=True)
+    settings.model_configs = [mc]
+    profile = _oci_profile()
+    profile.key_file = None
+    profile.key_content = SecretStr("-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----")
+
+    with (
+        patch("server.app.models.litellm_utils.litellm") as mock_litellm,
+        patch("server.app.models.litellm_utils.get_signer", return_value=None),
+    ):
+        mock_litellm.get_supported_openai_params.return_value = []
+        spec = LiteLlmModelSpec("oci", "cohere.command-r", oci_profile=profile)
+        result = spec.to_litellm_kwargs()
+
+    assert result["oci_key"] == "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----"
+    assert "oci_key_file" not in result
 
 
 # ---------------------------------------------------------------------------

--- a/src/server/tests/runtime/langgraph/adapters/test_litellm.py
+++ b/src/server/tests/runtime/langgraph/adapters/test_litellm.py
@@ -377,6 +377,58 @@ class TestClientParamsOverrides:
         kwargs = mock_completion.call_args.kwargs
         assert kwargs.get("drop_params") is True
 
+    @patch("server.app.runtime.langgraph.adapters.litellm.ChatLiteLLM.completion_with_retry")
+    def test_model_kwargs_forwarded_to_litellm_request(self, mock_completion):
+        """OCI auth and other model kwargs must reach the actual LiteLLM request."""
+        mock_completion.return_value = _non_streaming_response("ok")
+        llm = OracleChatLiteLLM(
+            model="oci/cohere.command-r",
+            model_kwargs={
+                "oci_region": "us-chicago-1",
+                "oci_compartment_id": "ocid1.compartment.oc1..test",
+                "oci_tenancy": "ocid1.tenancy.oc1..test",
+                "oci_user": "ocid1.user.oc1..test",
+                "oci_fingerprint": "aa:bb:cc",
+                "oci_key_file": "/path/to/key.pem",
+            },
+        )
+        llm._generate([HumanMessage(content="hi")])
+        kwargs = mock_completion.call_args.kwargs
+        assert kwargs["oci_region"] == "us-chicago-1"
+        assert kwargs["oci_compartment_id"] == "ocid1.compartment.oc1..test"
+        assert kwargs["oci_tenancy"] == "ocid1.tenancy.oc1..test"
+        assert kwargs["oci_key_file"] == "/path/to/key.pem"
+
+    @patch("server.app.runtime.langgraph.adapters.litellm.ChatLiteLLM.completion_with_retry")
+    def test_oci_openai_gpt5_uses_max_completion_tokens(self, mock_completion):
+        """OCI OpenAI GPT-5 models reject ``max_tokens``."""
+        mock_completion.return_value = _non_streaming_response("ok")
+        llm = OracleChatLiteLLM(model="oci/openai.gpt-5.5", max_tokens=1234)
+        llm._generate([HumanMessage(content="hi")])
+        kwargs = mock_completion.call_args.kwargs
+        assert kwargs["max_completion_tokens"] == 1234
+        assert "max_tokens" not in kwargs
+
+    @patch("server.app.runtime.langgraph.adapters.litellm.ChatLiteLLM.completion_with_retry")
+    def test_oci_openai_gpt5_converts_per_call_max_tokens(self, mock_completion):
+        """Per-call overrides are merged after ``_client_params`` and need conversion too."""
+        mock_completion.return_value = _non_streaming_response("ok")
+        llm = OracleChatLiteLLM(model="oci/openai.gpt-5.5")
+        llm._generate([HumanMessage(content="hi")], max_tokens=321)
+        kwargs = mock_completion.call_args.kwargs
+        assert kwargs["max_completion_tokens"] == 321
+        assert "max_tokens" not in kwargs
+
+    @patch("server.app.runtime.langgraph.adapters.litellm.ChatLiteLLM.completion_with_retry")
+    def test_oci_openai_gpt5_converts_streaming_max_tokens(self, mock_completion):
+        """Streaming paths pass kwargs through upstream, so they need boundary conversion."""
+        mock_completion.return_value = _stream_chunks("ok")
+        llm = OracleChatLiteLLM(model="oci/openai.gpt-5.5")
+        list(llm._stream([HumanMessage(content="hi")], max_tokens=222))
+        kwargs = mock_completion.call_args.kwargs
+        assert kwargs["max_completion_tokens"] == 222
+        assert "max_tokens" not in kwargs
+
 
 class TestStreamingFallback:
     """OracleChatLiteLLM falls back to non-streaming when the provider rejects stream=True."""

--- a/src/server/tests/runtime/multi_tool_base.py
+++ b/src/server/tests/runtime/multi_tool_base.py
@@ -86,6 +86,17 @@ class ClassificationBase:
             assert decision == "both"
             assert tu is None
 
+    @pytest.mark.anyio
+    async def test_classify_oci_openai_gpt5_uses_max_completion_tokens(self):
+        """OCI OpenAI GPT-5 classifiers reject ``max_tokens``."""
+        with patch("server.app.runtime.common.litellm.acompletion", new_callable=AsyncMock) as mock_acompletion:
+            mock_acompletion.return_value = self.mock_response("vecsearch")
+            session = self.make_session(classifier_model="oci/openai.gpt-5.5")
+            await session.classify("test query")
+            kwargs = mock_acompletion.call_args.kwargs
+            assert kwargs["max_completion_tokens"] == 10
+            assert "max_tokens" not in kwargs
+
 
 # ---------------------------------------------------------------------------
 # Routing base


### PR DESCRIPTION
The branch fixes a few related OCI/OpenAI integration problems:

GPT-5 and o-series models were sent max_tokens, but those models expect max_completion_tokens, so requests could fail.

LiteLLM’s OCI adapter translated token limits to maxTokens, while OCI’s OpenAI-compatible GPT-5 path needs maxCompletionTokens.

Unsupported generation params were leaking through, including temperature, top_p, frequency_penalty, and presence_penalty, which newer OpenAI reasoning models may reject.

Classifier calls had the same max_tokens issue, so routing/classification could fail when using an OCI OpenAI GPT-5 classifier.

LangGraph per-call and streaming overrides bypassed normalization, meaning some request paths still sent the wrong params even if model defaults were fixed.

OCI auth/model kwargs were not fully forwarded into actual LiteLLM calls, which could drop required OCI credentials or request options.

Inline OCI private key content was not mapped correctly, so profiles using key content instead of a key file would not authenticate properly.